### PR TITLE
OSX compatibility for source code.

### DIFF
--- a/PiwikTracker/PiwikTracker.m
+++ b/PiwikTracker/PiwikTracker.m
@@ -8,16 +8,23 @@
 
 #import "PiwikTracker.h"
 #import <CommonCrypto/CommonDigest.h>
+#if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#else
+#import <Cocoa/Cocoa.h>
+#include <sys/sysctl.h>
+#endif
 #import <CoreData/CoreData.h>
 #import <CoreLocation/CoreLocation.h>
 #import "PTEventEntity.h"
 
 
-#ifdef DEBUG
-#   define DLog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__)
-#else
-#   define DLog(...)
+#ifndef DLog
+#   ifdef DEBUG
+#       define DLog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__)
+#   else
+#       define DLog(...)
+#   endif
 #endif
 
 #define ALog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__)
@@ -213,6 +220,7 @@ static PiwikTracker *_sharedInstance;
     NSDictionary *defaultValues = @{PiwikUserDefaultOptOutKey : @NO};
     [[NSUserDefaults standardUserDefaults] registerDefaults:defaultValues];
 
+#if TARGET_OS_IPHONE
     // Notifications
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appDidBecomeActive:)
@@ -223,7 +231,7 @@ static PiwikTracker *_sharedInstance;
                                              selector:@selector(appDidEnterBackground:)
                                                  name:UIApplicationDidEnterBackgroundNotification
                                                object:nil];
-    
+#endif
     [self startDispatchTimer];
         
     return self;
@@ -403,25 +411,46 @@ static PiwikTracker *_sharedInstance;
     }
     
     // Set resolution
+#if TARGET_OS_IPHONE
     CGRect screenBounds = [[UIScreen mainScreen] bounds];
     CGFloat screenScale = [[UIScreen mainScreen] scale];
+#else
+      CGRect screenBounds = [[NSScreen mainScreen] frame];
+      CGFloat screenScale = [[NSScreen mainScreen] backingScaleFactor];
+#endif
     CGSize screenSize = CGSizeMake(CGRectGetWidth(screenBounds) * screenScale, CGRectGetHeight(screenBounds) * screenScale);
     [staticParameters setObject:[NSString stringWithFormat:@"%.0fx%.0f", screenSize.width, screenSize.height]
                      forKey:PiwikParameterScreenReseloution];
     
     [staticParameters setObject:self.clientID forKey:PiwikParameterVisitorID];
     
-    [staticParameters setObject:[NSString stringWithFormat:@"%d", self.totalNumberOfVisits] forKey:PiwikParameterTotalNumberOfVisits];
+    [staticParameters setObject:[NSString stringWithFormat:@"%ld", (unsigned long)self.totalNumberOfVisits] forKey:PiwikParameterTotalNumberOfVisits];
     
     // Timestamps
     [staticParameters setObject:[NSString stringWithFormat:@"%.0f", self.firstVisitTimestamp] forKey:PiwikParameterFirstVisitTimestamp];
     [staticParameters setObject:[NSString stringWithFormat:@"%.0f", self.previousVisitTimestamp] forKey:PiwikParameterPreviousVisitTimestamp];
     
     // Set custom variables - platform, OS version and application version
+      self.visitorCustomVariables = [NSMutableArray array];
+#if TARGET_OS_IPHONE
     UIDevice *device = [UIDevice currentDevice];
-    self.visitorCustomVariables = [NSMutableArray array];
     [self.visitorCustomVariables insertObject:customVariable(@"Platform", device.model) atIndex:0];
     [self.visitorCustomVariables insertObject:customVariable(@"OS version", device.systemVersion) atIndex:1];
+#else
+    NSString *model;
+    size_t length = 0;
+    sysctlbyname("hw.model", NULL, &length, NULL, 0);
+    if (length) {
+        char *m = malloc(length * sizeof(char));
+        sysctlbyname("hw.model", m, &length, NULL, 0);
+        model = [NSString stringWithUTF8String:m];
+        free(m);
+    } else {
+        model = @"Unknown";
+    }
+    [self.visitorCustomVariables insertObject:customVariable(@"Platform", model) atIndex:0];
+    [self.visitorCustomVariables insertObject:customVariable(@"OS version", [[NSProcessInfo processInfo] operatingSystemVersionString]) atIndex:1];
+#endif
     [self.visitorCustomVariables insertObject:customVariable(@"App version", self.appVersion) atIndex:2];
     [staticParameters setObject:[PiwikTracker encodeCustomVariables:self.visitorCustomVariables] forKey:PiwikParameterVisitScopeCustomVariables];
     
@@ -459,9 +488,9 @@ static PiwikTracker *_sharedInstance;
   NSCalendar *calendar = [NSCalendar currentCalendar];
   unsigned unitFlags = NSHourCalendarUnit | NSMinuteCalendarUnit |  NSSecondCalendarUnit;
   NSDateComponents *dateComponents = [calendar components:unitFlags fromDate:[NSDate date]];
-  [joinedParameters setObject:[NSString stringWithFormat:@"%d", [dateComponents hour]] forKey:PiwikParameterHours];
-  [joinedParameters setObject:[NSString stringWithFormat:@"%d", [dateComponents minute]] forKey:PiwikParameterMinutes];
-  [joinedParameters setObject:[NSString stringWithFormat:@"%d", [dateComponents second]] forKey:PiwikParameterSeconds];
+  [joinedParameters setObject:[NSString stringWithFormat:@"%ld", (long)[dateComponents hour]] forKey:PiwikParameterHours];
+  [joinedParameters setObject:[NSString stringWithFormat:@"%ld", (long)[dateComponents minute]] forKey:PiwikParameterMinutes];
+  [joinedParameters setObject:[NSString stringWithFormat:@"%ld", (long)[dateComponents second]] forKey:PiwikParameterSeconds];
     
   return joinedParameters;
 }
@@ -492,7 +521,7 @@ inline NSString* customVariable(NSString* name, NSString* value) {
   
   NSMutableArray *encodedVariables = [NSMutableArray array];
   [variables enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-    [encodedVariables addObject:[NSString stringWithFormat:@"\"%d\":%@", idx + 1, obj]];
+    [encodedVariables addObject:[NSString stringWithFormat:@"\"%ld\":%@", (long)idx + 1, obj]];
   }];
   
   return [NSString stringWithFormat:@"{%@}", [encodedVariables componentsJoinedByString:@","]];
@@ -892,7 +921,7 @@ inline NSString* userDefaultKeyWithSiteID(NSString *siteID, NSString *key) {
 + (NSString*)md5:(NSString*)input {
   const char* str = [input UTF8String];
   unsigned char result[CC_MD5_DIGEST_LENGTH];
-  CC_MD5(str, strlen(str), result);
+  CC_MD5(str, (CC_LONG)strlen(str), result);
   
   NSMutableString *hexString = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
   for(int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {


### PR DESCRIPTION
This commit makes piwiktracker buildable (and working) under OS X. The library, compiled with those changes, works on both iOS and OS X.
Changes are:
Headers needed for OS X
A trick to avoid redefinition of DLog (I already have it defined in my projects). :)
Modification on calls to accommodate the differences between UIKit and AppKit.
Some string-format modification accomodating differences in size between variables between OS X and iOS (mostly 32- vs. 64-bitness issues).
The OS X version can be compiled 64-bit only and it's tested only on 10.7+.
