### PR TITLE
New feature: Extra Visitor Custom Variables which can be updated per event.

### DIFF
--- a/PiwikTracker.podspec
+++ b/PiwikTracker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PiwikTracker"
-  s.version      = "2.5.2"
+  s.version      = "2.5.3"
   s.summary      = "A Piwik tracker written in Objective-C for iOS and OSX apps."
   s.homepage     = "https://github.com/piwik/piwik-sdk-ios/"
   s.license      = { :type => 'MIT', :file => 'LICENSE.md' }

--- a/PiwikTracker.xcodeproj/project.pbxproj
+++ b/PiwikTracker.xcodeproj/project.pbxproj
@@ -157,7 +157,7 @@
 		CD10FADD17B0378E0012BE50 /* PiwikTrackerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PiwikTrackerTests.m; sourceTree = "<group>"; };
 		CD10FAE917B037B50012BE50 /* PiwikTracker-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PiwikTracker-Prefix.pch"; sourceTree = "<group>"; };
 		CD10FAEA17B037B50012BE50 /* PiwikTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PiwikTracker.h; sourceTree = "<group>"; };
-		CD10FAEB17B037B50012BE50 /* PiwikTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PiwikTracker.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		CD10FAEB17B037B50012BE50 /* PiwikTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PiwikTracker.m; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		CD10FAED17B037B50012BE50 /* piwiktracker.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = piwiktracker.xcdatamodel; sourceTree = "<group>"; };
 		CD152F3B188BE59F0090BFD3 /* PiwikTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PiwikTransaction.h; sourceTree = "<group>"; };
 		CD152F41188C4B010090BFD3 /* PiwikTransactionItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PiwikTransactionItem.h; sourceTree = "<group>"; };

--- a/PiwikTracker/PiwikTracker.h
+++ b/PiwikTracker/PiwikTracker.h
@@ -11,7 +11,7 @@
 
 
 @class PiwikTransaction;
-
+@class CustomVariable;
 
 /**
  

--- a/PiwikTracker/PiwikTracker.h
+++ b/PiwikTracker/PiwikTracker.h
@@ -354,4 +354,36 @@
  */
 @property (nonatomic, strong) NSString *appVersion;
 
+/**
+ Set the extra custom visit variable at specific index.
+ 
+ Extra custom variables are permitted to be set as 4th or 5th custom variables.
+ 
+ @param index The index of the custom variable. Currently, only 4th and 5th indexes are permitted, the first three ones are reserved by iOS PiwikTracker.
+ @param name The name of the custom variable.
+ @param value The value of the custom variable as string.
+ @return YES if the extra custom variable is set, NO if the extra custom variable is not permitted to be set at that specific index.
+ */
+- (BOOL)setExtraCustomVariableAtIndex:(NSUInteger)index name:(NSString *)name value:(NSString *)value;
+
+/**
+ Get the extra custom visit variable at specific index.
+ 
+ Extra custom variables are permitted to be set as 4th or 5th custom variables.
+ 
+ @param index The index of the custom variable. Currently, only 4th and 5th indexes are permitted, the first three ones are reserved by iOS PiwikTracker.
+ @return The extra custom variable as CustomVariable object which is set at the specific index, nil if no custom variable has been set or index is not permitted (points to reserved custom variable).
+ */
+- (CustomVariable *)getExtraCustomVariableAtIndex:(NSUInteger)index;
+
+/**
+ Remove the extra custom visit variable at specific index.
+ 
+ Extra custom variables are permitted to be set as 4th or 5th custom variables.
+ 
+ @param index The index of the custom variable. Currently, only 4th and 5th indexes are permitted, the first three ones are reserved by iOS PiwikTracker.
+ @return The extra custom variable as CustomVariable object which is removed from the specific index, nil if no custom variable has been set or index is not permitted (points to reserved custom variable).
+ */
+- (CustomVariable *)removeExtraCustomVariableAtIndex:(NSUInteger)index;
+
 @end

--- a/PiwikTracker/PiwikTracker.m
+++ b/PiwikTracker/PiwikTracker.m
@@ -1234,7 +1234,7 @@ inline NSString* UserDefaultKeyWithSiteID(NSString *siteID, NSString *key) {
     if (index <= PiwikCustomVariablesNumberOfReserved || index > 5)
         return NO;
     
-    CustomVariable *theCustomVar = [CustomVariable alloc] initWithIndex:index name:name value:value;
+    CustomVariable *theCustomVar = [[CustomVariable alloc] initWithIndex:index name:name value:value];
     
     if (!self.visitorExtraCustomVariables)
         self.visitorExtraCustomVariables = [NSMutableArray array];

--- a/PiwikTracker/PiwikTracker.m
+++ b/PiwikTracker/PiwikTracker.m
@@ -88,6 +88,9 @@ static NSUInteger const PiwikCustomVariablesMaxNameLength = 20;
 static NSUInteger const PiwikCustomVariablesMaxValueLengt = 100;
  */
 
+// Custom variables (including Extra ones)
+static NSUInteger const PiwikCustomVariablesNumberOfReserved = 3;
+
 // Default values
 static NSUInteger const PiwikDefaultSessionTimeout = 120;
 static NSUInteger const PiwikDefaultDispatchTimer = 120;
@@ -152,7 +155,8 @@ static NSString * const PiwikURLCampaignKeyword = @"pk_kwd";
 @property (nonatomic, strong) NSDate *appDidEnterBackgroundDate;
 
 @property (nonatomic, strong) NSMutableArray *visitorCustomVariables;
-@property (nonatomic, strong) NSDictionary *sessionParameters;
+@property (nonatomic, strong) NSMutableArray *visitorExtraCustomVariables;
+@property (nonatomic, strong) NSMutableDictionary *sessionParameters;
 @property (nonatomic, strong) NSDictionary *staticParameters;
 @property (nonatomic, strong) NSDictionary *campaignParameters;
 
@@ -749,11 +753,22 @@ static PiwikTracker *_sharedInstance;
     
     self.visitorCustomVariables[2] = [[CustomVariable alloc] initWithIndex:3 name:@"App version" value:self.appVersion];
     
-    sessionParameters[PiwikParameterVisitScopeCustomVariables] = [PiwikTracker JSONEncodeCustomVariables:self.visitorCustomVariables];
+    //sessionParameters[PiwikParameterVisitScopeCustomVariables] = [PiwikTracker JSONEncodeCustomVariables:self.visitorCustomVariables];
     
     self.sessionParameters = sessionParameters;
   }
   
+  // Add Extra Visitor Custom Variables per queueEvent (for every event, screen etc) and NOT on new session only!
+  NSMutableArray *joinedCustomVariables = [[NSMutableArray alloc] initWithArray:self.visitorCustomVariables];
+  for (id aCustomVariable in self.visitorExtraCustomVariables) {
+    if ([aCustomVariable isKindOfClass:[CustomVariable class]]) {
+      CustomVariable *theCustomVar = (CustomVariable *)aCustomVariable;
+      [joinedCustomVariables addObject:theCustomVar];
+    }
+  }
+  
+  self.sessionParameters[PiwikParameterVisitScopeCustomVariables] = [PiwikTracker JSONEncodeCustomVariables:joinedCustomVariables];
+    
   // Join event parameters with session parameters
   NSMutableDictionary *joinedParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
   [joinedParameters addEntriesFromDictionary:self.sessionParameters];
@@ -1213,6 +1228,72 @@ inline NSString* UserDefaultKeyWithSiteID(NSString *siteID, NSString *key) {
   return _appVersion;
 }
 
+#pragma mark - Extra Custom Variables
+- (BOOL)setExtraCustomVariableAtIndex:(NSUInteger)index name:(NSString *)name value:(NSString *)value {
+    // First, check permitted indexes, should not be an index of reserved custom variables and not bigger than total 5.
+    if (index <= PiwikCustomVariablesNumberOfReserved || index > 5)
+        return NO;
+    
+    CustomVariable *theCustomVar = [CustomVariable alloc] initWithIndex:index name:name value:value;
+    
+    if (!self.visitorExtraCustomVariables)
+        self.visitorExtraCustomVariables = [NSMutableArray array];
+    
+    // Internal index for visitorExtraCustomVariables, for ex. index 4 correspondes to internalIndex 0 if reserved custom variables are 3.
+    NSUInteger internalIndex = index - PiwikCustomVariablesNumberOfReserved - 1;
+    
+    // Check if internalIndex is out of current array's bound, fill empty indexes with NSNull objects
+    if (internalIndex > self.visitorExtraCustomVariables.count) {
+        NSUInteger numOfEmptyIndxs = internalIndex - self.visitorExtraCustomVariables.count;
+        for (NSUInteger i=0; i<numOfEmptyIndxs; i++) {
+            self.visitorExtraCustomVariables[i] = [[NSNull alloc] init];
+        }
+    }
+    
+    [self.visitorExtraCustomVariables setObject:theCustomVar atIndexedSubscript:internalIndex];
+    
+    return YES;
+}
+
+- (CustomVariable *)getExtraCustomVariableAtIndex:(NSUInteger)index {
+    // First, check permitted indexes, should not be an index of reserved custom variables and not bigger than total 5.
+    if (index <= PiwikCustomVariablesNumberOfReserved || index > 5)
+        return nil;
+    
+    // Internal index for visitorExtraCustomVariables, for ex. index 4 correspondes to internalIndex 0 if reserved custom variables are 3.
+    NSUInteger internalIndex = index - PiwikCustomVariablesNumberOfReserved - 1;
+
+    // There are not set custom variables at all or no at requested index
+    if (!self.visitorExtraCustomVariables || self.visitorExtraCustomVariables.count <= internalIndex)
+        return nil;
+    
+    // Check if object at requested index is CustomVariable or NSNull object
+    if ([self.visitorExtraCustomVariables[internalIndex] isKindOfClass:[NSNull class]])
+        return nil;
+    else
+        return [self.visitorExtraCustomVariables objectAtIndex:internalIndex];
+}
+
+- (CustomVariable *)removeExtraCustomVariableAtIndex:(NSUInteger)index {
+    // First, check permitted indexes, should not be an index of reserved custom variables and not bigger than total 5.
+    if (index <= PiwikCustomVariablesNumberOfReserved || index > 5)
+        return nil;
+    
+    // Internal index for visitorExtraCustomVariables, for ex. index 4 correspondes to internalIndex 0 if reserved custom variables are 3.
+    NSUInteger internalIndex = index - PiwikCustomVariablesNumberOfReserved - 1;
+    
+    CustomVariable *removedCustomVariable;
+    
+    // Check if object at requested index is CustomVariable or NSNull object
+    if ([self.visitorExtraCustomVariables[internalIndex] isKindOfClass:[NSNull class]])
+        return nil;
+    else {
+        removedCustomVariable = [[self.visitorExtraCustomVariables objectAtIndex:internalIndex] copy];
+        self.visitorExtraCustomVariables[internalIndex] = [[NSNull alloc] init];
+    }
+    
+    return removedCustomVariable;
+}
 
 #pragma mark - Help methods
 


### PR DESCRIPTION
PiwikTracker for iOS supports Visitor Custom Variables which are created on each new app session, they are regarding tracking of iOS device, iOS platform version and app's version as well. The main drawback is that the developer has no option to change those custom variables through PiwikTracker library methods because they are "hardcoded" in library code. 

The new feature, I has added, permits the set of custom variables programmatically while preserves the PiwikTracker's library reserved ones. Additionally, those extra custom variables can be updated on every send view, send event etc "action" and not only on new session as the PiwikTracker's reserved / hardcoded custom variables do.

You can set, get and remove an extra custom variable at specific index with the respective newly implemented methods. Constant: 

static NSUInteger const PiwikCustomVariablesNumberOfReserved = 3;

declares the number of reserved custom variables that PiwikTracker uses (currently is 3). Also, I assume that the max number of custom variables is 5, so with 3 reserved, only two extra custom variables can be defined (at indexes: 4 and 5). If you change the above constant of the reserved custom variables, methods are flexible enough so you can set extra custom variables at all available indexes up to 5.

Enjoy!
