### PR TITLE
Add custom user agent to tracker.

### DIFF
--- a/PiwikTracker+AFNetworking2/PiwikAFNetworking2Dispatcher.m
+++ b/PiwikTracker+AFNetworking2/PiwikAFNetworking2Dispatcher.m
@@ -9,7 +9,11 @@
 #import "PiwikAFNetworking2Dispatcher.h"
 #import "AFNetworking.h"
 
+@interface PiwikAFNetworking2Dispatcher ()
 
+@property (nonatomic, strong) NSString *customUserAgent;
+
+@end
 
 @implementation PiwikAFNetworking2Dispatcher
 
@@ -22,6 +26,10 @@
   return self;
 }
 
+- (void)setCustomUserAgent:(NSString *)customUserAgent
+{
+    _customUserAgent = customUserAgent;
+}
 
 - (void)sendSingleEventWithParameters:(NSDictionary*)parameters
                               success:(void (^)())successBlock
@@ -29,7 +37,11 @@
   
   self.requestSerializer = [AFHTTPRequestSerializer serializer];
   self.responseSerializer = [AFImageResponseSerializer serializer];
-  
+
+  if (self.customUserAgent) {
+    [self.requestSerializer setValue:self.customUserAgent forHTTPHeaderField:@"User-Agent"];
+  }
+
   [self GET:@"" parameters:parameters success:^(NSURLSessionDataTask *task, id responseObject) {
     
     //NSLog(@"Successfully sent stats to Piwik server");
@@ -51,6 +63,10 @@
   
   self.requestSerializer = [AFJSONRequestSerializer serializerWithWritingOptions:kNilOptions];
   self.responseSerializer = [AFJSONResponseSerializer serializer];
+    
+  if (self.customUserAgent) {
+    [self.requestSerializer setValue:self.customUserAgent forHTTPHeaderField:@"User-Agent"];
+  }
     
   [self POST:@"" parameters:parameters success:^(NSURLSessionDataTask *task, id responseObject) {
     

--- a/PiwikTracker/PiwikDebugDispatcher.m
+++ b/PiwikTracker/PiwikDebugDispatcher.m
@@ -11,6 +11,10 @@
 
 @implementation PiwikDebugDispatcher
 
+- (void)setCustomUserAgent:(NSString *)customUserAgent
+{
+    NSLog(@"Custom user agent: \n%@", customUserAgent);
+}
 
 - (void)sendSingleEventWithParameters:(NSDictionary*)parameters
                               success:(void (^)())successBlock

--- a/PiwikTracker/PiwikDispatcher.h
+++ b/PiwikTracker/PiwikDispatcher.h
@@ -20,6 +20,12 @@
  */
 @protocol PiwikDispatcher <NSObject>
 
+/**
+ *  Set a custom user agent the dispatchers will use for requests.
+ *
+ *  @param customUserAgent The user agent string.
+ */
+- (void)setCustomUserAgent:(NSString *)customUserAgent;
 
 /**
  Send a single tracking event to the Piwik server.

--- a/PiwikTracker/PiwikNSURLSessionDispatcher.m
+++ b/PiwikTracker/PiwikNSURLSessionDispatcher.m
@@ -12,6 +12,7 @@
 @interface PiwikNSURLSessionDispatcher ()
 
 @property (nonatomic, strong) NSURL *piwikURL;
+@property (nonatomic, strong) NSString *customUserAgent;
 
 @end
 
@@ -30,6 +31,10 @@ static NSUInteger const PiwikHTTPRequestTimeout = 5;
   return self;
 }
 
+- (void)setCustomUserAgent:(NSString *)customUserAgent
+{
+    _customUserAgent = customUserAgent;
+}
 
 - (void)sendSingleEventWithParameters:(NSDictionary*)parameters
                               success:(void (^)())successBlock
@@ -50,6 +55,10 @@ static NSUInteger const PiwikHTTPRequestTimeout = 5;
                                   initWithURL:URL
                                   cachePolicy:NSURLRequestReloadIgnoringCacheData
                                   timeoutInterval:PiwikHTTPRequestTimeout];
+  if (self.customUserAgent) {
+    [request setValue:self.customUserAgent forHTTPHeaderField:@"User-Agent"];
+  }
+    
   request.HTTPMethod = @"GET";
   
   [self sendRequest:request success:successBlock failure:failureBlock];
@@ -66,6 +75,10 @@ static NSUInteger const PiwikHTTPRequestTimeout = 5;
   NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.piwikURL
                                                               cachePolicy:NSURLRequestReloadIgnoringCacheData
                                                           timeoutInterval:PiwikHTTPRequestTimeout];
+  if (self.customUserAgent) {
+    [request setValue:self.customUserAgent forHTTPHeaderField:@"User-Agent"];
+  }
+    
   request.HTTPMethod = @"POST";
   
   NSString *charset = (__bridge NSString *)CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding));

--- a/PiwikTracker/PiwikTracker.h
+++ b/PiwikTracker/PiwikTracker.h
@@ -246,6 +246,18 @@ typedef NS_ENUM(NSUInteger, CustomVariableScope) {
 - (BOOL)sendOutlink:(NSString*)url;
 
 /**
+ @name Track downloads
+ */
+
+/**
+ *  Track a download.
+ *
+ *  @param url The url which leads to the downloaded file.
+ *  @return YES if the event was queued for dispatching.
+ */
+- (BOOL)sendDownload:(NSString *)url;
+
+/**
  Track an user interaction as a custom event.
  
  @warning As of Piwik server 2.3 events are presented in a separate section and support sending a numeric value (float or integer). The Piwik tracker support this out of the box. 

--- a/PiwikTracker/PiwikTracker.h
+++ b/PiwikTracker/PiwikTracker.h
@@ -178,6 +178,14 @@ typedef NS_ENUM(NSUInteger, CustomVariableScope) {
 
 
 /**
+ Custom user agent.
+ 
+ A custom user agent the dispatchers will use for requests.
+ */
+@property (nonatomic, strong) NSString *customUserAgent;
+
+
+/**
  @name Session control
  */
 

--- a/PiwikTracker/PiwikTracker.m
+++ b/PiwikTracker/PiwikTracker.m
@@ -333,6 +333,10 @@ static PiwikTracker *_sharedInstance;
 
 }
 
+- (void)setCustomUserAgent:(NSString *)customUserAgent
+{
+    [self.dispatcher setCustomUserAgent:customUserAgent];
+}
 
 - (void)startDispatchTimer {
   

--- a/PiwikTracker/PiwikTracker.m
+++ b/PiwikTracker/PiwikTracker.m
@@ -84,6 +84,7 @@ static NSString * const PiwikParameterSearchKeyword = @"search";
 static NSString * const PiwikParameterSearchCategory = @"search_cat";
 static NSString * const PiwikParameterSearchNumberOfHits = @"search_count";
 static NSString * const PiwikParameterLink = @"link";
+static NSString * const PiwikParameterDownload = @"download";
 // Ecommerce
 static NSString * const PiwikParameterTransactionIdentifier = @"ec_id";
 static NSString * const PiwikParameterTransactionSubTotal = @"ec_st";
@@ -441,6 +442,18 @@ static PiwikTracker *_sharedInstance;
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     
     params[PiwikParameterLink] = url;
+    
+    // Setting the url is mandatory
+    params[PiwikParameterURL] = url;
+    
+    return [self queueEvent:params];
+}
+
+- (BOOL)sendDownload:(NSString *)url
+{
+    NSMutableDictionary *params = [NSMutableDictionary dictionary];
+    
+    params[PiwikParameterDownload] = url;
     
     // Setting the url is mandatory
     params[PiwikParameterURL] = url;

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ The Piwik SDK is easy to configure and use:
 // Track outlinks to external websites and apps
 [[PiwikTracker sharedInstance] sendOutlink:@"anotherapp://somwhere/else?origin=myapp"];
 
+// Track downloads
+[[PiwikTracker sharedInstance] sendDownload:@"http://somwhere/else/file.txt"];
+
 // Track ecommerce transactions
 PiwikTransaction *transaction = [PiwikTransaction transactionWithBuilder:^(PiwikTransactionBuilder *builder) {
   builder.identifier =


### PR DESCRIPTION
Hello @mattiaslevin,

we have added a feature to make the tracker use a custom user agent when sending tracking data to the backend.

The feature basically consists of an `NSString` property on the `PiwikTracker` class. When set the value is forwarded to the dispatcher instance through the `PiwikDispatcher` protocol and then added to the HTTP header of the HTTP requests.

Best regards
Julian Krumow