### PR TITLE
load MOM from PiwikTracker class's bundle

### DIFF
--- a/PiwikTracker/PiwikTracker.m
+++ b/PiwikTracker/PiwikTracker.m
@@ -1565,7 +1565,7 @@ inline NSString* UserDefaultKeyWithSiteID(NSString *siteID, NSString *key) {
     return _managedObjectModel;
   }
   
-  NSURL *modelURL = [[NSBundle mainBundle] URLForResource:@"piwiktracker" withExtension:@"momd"];
+  NSURL *modelURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"piwiktracker" withExtension:@"momd"];
   _managedObjectModel = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
   
   return _managedObjectModel;


### PR DESCRIPTION
Prevents exceptions when integrated as a framework (e.g. using CocoaPods with `use_frameworks!`).