### PR TITLE
Provide the right path for managed object model

### DIFF
--- a/PiwikTracker/PiwikTracker.m
+++ b/PiwikTracker/PiwikTracker.m
@@ -1565,7 +1565,7 @@ inline NSString* UserDefaultKeyWithSiteID(NSString *siteID, NSString *key) {
     return _managedObjectModel;
   }
   
-  NSURL *modelURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"piwiktracker" withExtension:@"momd"];
+  NSURL *modelURL = [[NSBundle mainBundle] URLForResource:@"/Frameworks/PiwikTracker.framework/piwiktracker" withExtension:@"momd"];
   _managedObjectModel = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
   
   return _managedObjectModel;


### PR DESCRIPTION
The managed object model has moved to a different path so the initialisation causes a crash. This PR initialises mom with the right path