### PR TITLE
change performBlock ->performBlockAndWait in func deleteEventsWithIDs

### DIFF
--- a/PiwikTracker/PiwikTracker.m
+++ b/PiwikTracker/PiwikTracker.m
@@ -1501,22 +1501,20 @@ inline NSString* UserDefaultKeyWithSiteID(NSString *siteID, NSString *key) {
 
 - (void)deleteEventsWithIDs:(NSArray*)entityIDs {
 
-  [self.managedObjectContext performBlock:^{
-    
-    NSError *error;
-    
-    for (NSManagedObjectID *entityID in entityIDs) {
-      
-      PTEventEntity *event = (PTEventEntity*)[self.managedObjectContext existingObjectWithID:entityID error:&error];
-      if (event) {
-        [self.managedObjectContext deleteObject:event];
-      }
-
-    }
-    
-    [self.managedObjectContext save:&error];
-    
-  }];
+    [self.managedObjectContext performBlockAndWait:^{
+        NSError *error;
+        
+        for (NSManagedObjectID *entityID in entityIDs) {
+            
+            PTEventEntity *event = (PTEventEntity*)[self.managedObjectContext existingObjectWithID:entityID error:&error];
+            if (event) {
+                [self.managedObjectContext deleteObject:event];
+            }
+            
+        }
+        
+        [self.managedObjectContext save:&error];
+    }];
   
 }
 


### PR DESCRIPTION
I found crashs located in the function "- (void)deleteEventsWithIDs:(NSArray*)entityIDs".
Because the api "- (void)performBlock:(void (^)())block" is asynchronously.Maybe you fecth the entitys from the database when deleting , you will fetch the data is deleting.So i suggest use the api "- (void)performBlockAndWait:(void (^)())block" instand of "- (void)performBlock:(void (^)())block".
 