### PR TITLE
fixed wrong encoding of the eventValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* **fixed** The value of an event got wronly encoded when dispatching. [#140](https://github.com/piwik/piwik-sdk-ios/pull/140)
+
 ## 4.0.0-beta1
 * no changes
 

--- a/PiwikTracker/URLSessionDispatcher.swift
+++ b/PiwikTracker/URLSessionDispatcher.swift
@@ -95,7 +95,7 @@ fileprivate extension Event {
                 URLQueryItem(name: "e_c", value: eventCategory),
                 URLQueryItem(name: "e_a", value: eventAction),
                 URLQueryItem(name: "e_n", value: eventName),
-                URLQueryItem(name: "e_v", value: eventValue != nil ? "\(eventValue)" : nil),
+                URLQueryItem(name: "e_v", value: eventValue != nil ? "\(eventValue!)" : nil),
                 
                 ].filter({ $0.value != nil }) // remove the items that lack the value
         }


### PR DESCRIPTION
Encoding an optional string value like before would encode it like `Optional(0.0)`.