### PR TITLE
Feature/136 starting sessions

### DIFF
--- a/Example/iOS Example/AppDelegate.swift
+++ b/Example/iOS Example/AppDelegate.swift
@@ -19,10 +19,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+        Tracker.shared?.dispatch()
     }
     
     func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+        Tracker.shared?.startNewSession()
     }
     
     func applicationDidBecomeActive(_ application: UIApplication) {

--- a/Example/iOS Example/ConfigurationViewController.swift
+++ b/Example/iOS Example/ConfigurationViewController.swift
@@ -27,6 +27,7 @@ class ConfigurationViewController: UIViewController {
     }
     
     @IBAction func newSessionButtonTapped(_ sender: UIButton) {
+        Tracker.shared?.startNewSession()
     }
     
     @IBAction func dispatchButtonTapped(_ sender: UIButton) {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - Nimble (5.1.1)
-  - PiwikTracker (4.0.0-alpha1):
-    - PiwikTracker/Core (= 4.0.0-alpha1)
-  - PiwikTracker/Core (4.0.0-alpha1)
+  - PiwikTracker (4.0.0-beta1):
+    - PiwikTracker/Core (= 4.0.0-beta1)
+  - PiwikTracker/Core (4.0.0-beta1)
   - Quick (0.10.0)
 
 DEPENDENCIES:
@@ -16,7 +16,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Nimble: 415e3aa3267e7bc2c96b05fa814ddea7bb686a29
-  PiwikTracker: 6a8cebd3663430091db323dd93047be254e77bc3
+  PiwikTracker: 9a2fb2fe96ff5330719c05d7f77e73a9ed4b2237
   Quick: 5d290df1c69d5ee2f0729956dcf0fd9a30447eaa
 
 PODFILE CHECKSUM: a7f24eb0ec9a2aaa14dbc693f87f65c7b3ca1934


### PR DESCRIPTION
This PR implements the #136. I slightly changed the API from `newSession()` to `startNewSession()` to be more clear about what this does. Also I thought about when to automatically start a new session. I think the minimal setup for a new Session is on app start. So I did not implement it for app foregrounding.