### PR TITLE
Fixed issue where tracking an event wasn’t possible from Objective-C code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * **fixed** The value of an event got wronly encoded when dispatching. [#140](https://github.com/piwik/piwik-sdk-ios/pull/140)
+* **fixed** Fixed an issue where tracking an event wasn’t possible from Objective-C code. [#142](https://github.com/piwik/piwik-sdk-ios/issues/142)
 
 ## 4.0.0-beta1
 * no changes

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		1F03BC991E86CC7E0002F0AD /* EventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F03BC981E86CC7E0002F0AD /* EventsViewController.swift */; };
 		1F03BC9B1E86CF770002F0AD /* ScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F03BC9A1E86CF770002F0AD /* ScreenViewController.swift */; };
 		1F03BC9D1E86CFC30002F0AD /* SecondScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F03BC9C1E86CFC30002F0AD /* SecondScreenViewController.swift */; };
+		1F71BBC41ED5F108003A5460 /* ObjectiveCCompatibilityChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F71BBC31ED5F108003A5460 /* ObjectiveCCompatibilityChecker.m */; };
 		1F72DA6F1E61ECAF00EFF764 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F72DA6E1E61ECAF00EFF764 /* AppDelegate.swift */; };
 		1F72DA711E62E55200EFF764 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F72DA701E62E55200EFF764 /* MenuViewController.swift */; };
 		1F72DA731E62E78E00EFF764 /* ConfigurationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F72DA721E62E78E00EFF764 /* ConfigurationViewController.swift */; };
@@ -68,6 +69,8 @@
 		1F03BC981E86CC7E0002F0AD /* EventsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsViewController.swift; sourceTree = "<group>"; };
 		1F03BC9A1E86CF770002F0AD /* ScreenViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenViewController.swift; sourceTree = "<group>"; };
 		1F03BC9C1E86CFC30002F0AD /* SecondScreenViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecondScreenViewController.swift; sourceTree = "<group>"; };
+		1F71BBC21ED5F108003A5460 /* ObjectiveCCompatibilityChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectiveCCompatibilityChecker.h; sourceTree = "<group>"; };
+		1F71BBC31ED5F108003A5460 /* ObjectiveCCompatibilityChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjectiveCCompatibilityChecker.m; sourceTree = "<group>"; };
 		1F72DA6D1E61ECAF00EFF764 /* ios-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ios-Bridging-Header.h"; sourceTree = "<group>"; };
 		1F72DA6E1E61ECAF00EFF764 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1F72DA701E62E55200EFF764 /* MenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
@@ -228,6 +231,8 @@
 				CDA9500519F05D56004A2277 /* UserIDViewController.h */,
 				CDA9500619F05D56004A2277 /* UserIDViewController.m */,
 				1F72DA6D1E61ECAF00EFF764 /* ios-Bridging-Header.h */,
+				1F71BBC21ED5F108003A5460 /* ObjectiveCCompatibilityChecker.h */,
+				1F71BBC31ED5F108003A5460 /* ObjectiveCCompatibilityChecker.m */,
 			);
 			path = "iOS Example";
 			sourceTree = "<group>";
@@ -403,6 +408,7 @@
 				1F03BC9D1E86CFC30002F0AD /* SecondScreenViewController.swift in Sources */,
 				1F72DA6F1E61ECAF00EFF764 /* AppDelegate.swift in Sources */,
 				1F03BC991E86CC7E0002F0AD /* EventsViewController.swift in Sources */,
+				1F71BBC41ED5F108003A5460 /* ObjectiveCCompatibilityChecker.m in Sources */,
 				1F03BC9B1E86CF770002F0AD /* ScreenViewController.swift in Sources */,
 				1F72DA711E62E55200EFF764 /* MenuViewController.swift in Sources */,
 				1F72DA731E62E78E00EFF764 /* ConfigurationViewController.swift in Sources */,

--- a/Example/iOS Example/ObjectiveCCompatibilityChecker.h
+++ b/Example/iOS Example/ObjectiveCCompatibilityChecker.h
@@ -1,0 +1,7 @@
+// We use this file to check if all calls are usable from Objective-C code.
+
+#import <Foundation/Foundation.h>
+
+@interface ObjectiveCCompatibilityCheker : NSObject
+
+@end

--- a/Example/iOS Example/ObjectiveCCompatibilityChecker.m
+++ b/Example/iOS Example/ObjectiveCCompatibilityChecker.m
@@ -1,0 +1,14 @@
+@import PiwikTracker;
+
+#import "ObjectiveCCompatibilityChecker.h"
+
+@implementation ObjectiveCCompatibilityChecker
+
+- (void)check {
+    [Tracker configureSharedInstanceWithSiteID:@"5" baseURL:[NSURL URLWithString:@"http://example.com/piwik.php"]];
+    [[Tracker shared] trackWithView:@[@"example"]];
+    [[Tracker shared] trackWithEventWithCategory:@"category" action:@"action" name:nil number:nil];
+    [[Tracker shared] dispatch];
+}
+
+@end

--- a/PiwikTracker/Tracker.swift
+++ b/PiwikTracker/Tracker.swift
@@ -186,3 +186,13 @@ extension Tracker {
         queue(event: event(withCategory: category, action: action, name: name, value: value))
     }
 }
+
+// Objective-c compatibility extension
+extension Tracker {
+    
+    @objc public func track(eventWithCategory category: String, action: String, name: String? = nil, number: NSNumber? = nil) {
+        let value = number == nil ? nil : number!.floatValue
+        track(eventWithCategory: category, action: action, name: name, value: value)
+    }
+}
+

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - Nimble (5.1.1)
-  - PiwikTracker (4.0.0-alpha1):
-    - PiwikTracker/Core (= 4.0.0-alpha1)
-  - PiwikTracker/Core (4.0.0-alpha1)
+  - PiwikTracker (4.0.0-beta1):
+    - PiwikTracker/Core (= 4.0.0-beta1)
+  - PiwikTracker/Core (4.0.0-beta1)
   - Quick (0.10.0)
 
 DEPENDENCIES:
@@ -16,7 +16,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Nimble: 415e3aa3267e7bc2c96b05fa814ddea7bb686a29
-  PiwikTracker: 6a8cebd3663430091db323dd93047be254e77bc3
+  PiwikTracker: 9a2fb2fe96ff5330719c05d7f77e73a9ed4b2237
   Quick: 5d290df1c69d5ee2f0729956dcf0fd9a30447eaa
 
 PODFILE CHECKSUM: a7f24eb0ec9a2aaa14dbc693f87f65c7b3ca1934


### PR DESCRIPTION
Fixes #142

I also added the ObjectiveCCompatibilityChecker in the test app to ensure that we will keep the Objective-C compatibility. 