### PR TITLE
Added the possibility to set the url for a sreen view event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* **feature** Added the possibility to set the url for a sreen view event. [#92](https://github.com/piwik/piwik-sdk-ios/issues/92)
 * **fixed** The value of an event got wronly encoded when dispatching. [#140](https://github.com/piwik/piwik-sdk-ios/pull/140)
 
 ## 4.0.0-beta1

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		AD6EA65F0F2334BE1EBF2A97 /* [CP] Copy Pods Resources */ = {

--- a/PiwikTracker.xcodeproj/project.pbxproj
+++ b/PiwikTracker.xcodeproj/project.pbxproj
@@ -323,7 +323,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		F440219733D7385F192471AC /* [CP] Copy Pods Resources */ = {

--- a/PiwikTracker/Tracker.swift
+++ b/PiwikTracker/Tracker.swift
@@ -132,14 +132,15 @@ extension Tracker {
 }
 
 extension Tracker {
-    internal func event(action: [String]) -> Event {
+    internal func event(action: [String], url: URL? = nil) -> Event {
+        let url = url ?? URL(string: "http://example.com")!.appendingPathComponent(action.joined(separator: "/"))
         return Event(
             siteId: siteId,
             uuid: NSUUID(),
             visitor: visitor,
             session: session,
             date: Date(),
-            url: URL(string: "http://example.com")!.appendingPathComponent(action.joined(separator: "/")),
+            url: url,
             actionName: action,
             language: Locale.httpAcceptLanguage,
             isNewSession: false, // set this to true once we can start a new session
@@ -177,8 +178,9 @@ extension Tracker {
     /// This method can be used to track hierarchical screen names, e.g. screen/settings/register. Use this to create a hierarchical and logical grouping of screen views in the Piwik web interface.
     ///
     /// - Parameter view: An array of hierarchical screen names.
-    public func track(view: [String]) {
-        queue(event: event(action: view))
+    /// - Parameter url: The url of the page that was viewed. If none set the url will be http://example.com appended by the screen segments. Example: http://example.com/players/john-appleseed
+    public func track(view: [String], url: URL? = nil) {
+        queue(event: event(action: view, url: url))
     }
     
     /// Tracks an event as described here: https://piwik.org/docs/event-tracking/

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - Nimble (5.1.1)
-  - PiwikTracker (4.0.0-alpha1):
-    - PiwikTracker/Core (= 4.0.0-alpha1)
-  - PiwikTracker/Core (4.0.0-alpha1)
+  - PiwikTracker (4.0.0-beta1):
+    - PiwikTracker/Core (= 4.0.0-beta1)
+  - PiwikTracker/Core (4.0.0-beta1)
   - Quick (0.10.0)
 
 DEPENDENCIES:
@@ -16,9 +16,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Nimble: 415e3aa3267e7bc2c96b05fa814ddea7bb686a29
-  PiwikTracker: 6a8cebd3663430091db323dd93047be254e77bc3
+  PiwikTracker: 9a2fb2fe96ff5330719c05d7f77e73a9ed4b2237
   Quick: 5d290df1c69d5ee2f0729956dcf0fd9a30447eaa
 
 PODFILE CHECKSUM: a7f24eb0ec9a2aaa14dbc693f87f65c7b3ca1934
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.2.1

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ The PiwikTracker can track hierarchical screen names, e.g. screen/settings/regis
 Tracker.shared?.track(view: ["path","to","your","page"])
 ```
 
+You can also set the url of the page. 
+```
+let url = URL(string: "https://piwik.org/get-involved/")
+Tracker.shared?.track(view: ["community","get-involved"], url: url)
+```
+
 ### Tracking Events
 
 Events can be used to track user interactions such as taps on a button. An event consists of four parts:


### PR DESCRIPTION
Implements the request in issue #92 

The track-view function now has an optional url parameter.

```Swift
let url = URL(string: "https://piwik.org/get-involved/")
Tracker.shared?.track(view: ["community","get-involved"], url: url)
```