### PR TITLE
Adds support for Carthage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Exclude the build directory
 build/*
+DerivedData
  
 # Exclude temp nibs and swap files
 *~.nib
@@ -19,6 +20,8 @@ xcuserdata
 
 # Exclude generate documentation
 Doc/
+
+# Exclude build products from dependency managers
 Pods
-DerivedData
 /Podfile.lock
+Carthage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: objective-c
 before_install:
     - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
     - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+    - brew install carthage
     - cd $TRAVIS_BUILD_DIR
     - pod install || pod install --repo-update
-script: rake test
+script:
+  - rake test
+  - rake build_with_package_manager
 osx_image: xcode8.3
 cache: cocoapods

--- a/Example/ios/ios.xcodeproj/project.pbxproj
+++ b/Example/ios/ios.xcodeproj/project.pbxproj
@@ -331,9 +331,12 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/../../Pods/Target Support Files/Pods-example-ios/Pods-example-ios-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/PiwikTracker-iOS/PiwikTracker.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PiwikTracker.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -346,13 +349,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-example-ios-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CDC3360217B97B190098386C /* Build appledoc */ = {

--- a/Example/macos/macos.xcodeproj/project.pbxproj
+++ b/Example/macos/macos.xcodeproj/project.pbxproj
@@ -161,13 +161,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-example-macos-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		50DAC7215CB8D45774949E1F /* [CP] Embed Pods Frameworks */ = {
@@ -176,9 +179,12 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/../../Pods/Target Support Files/Pods-example-macos/Pods-example-macos-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/PiwikTracker-macOS/PiwikTracker.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PiwikTracker.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/tvos/tvos.xcodeproj/project.pbxproj
+++ b/Example/tvos/tvos.xcodeproj/project.pbxproj
@@ -161,9 +161,12 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/../../Pods/Target Support Files/Pods-example-tvos/Pods-example-tvos-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/PiwikTracker-tvOS/PiwikTracker.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PiwikTracker.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -191,13 +194,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-example-tvos-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/PiwikTracker.xcodeproj/project.pbxproj
+++ b/PiwikTracker.xcodeproj/project.pbxproj
@@ -311,9 +311,14 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-PiwikTrackerTests/Pods-PiwikTrackerTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
+				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -326,13 +331,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-PiwikTrackerTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F440219733D7385F192471AC /* [CP] Copy Pods Resources */ = {

--- a/PiwikTracker.xcodeproj/project.pbxproj
+++ b/PiwikTracker.xcodeproj/project.pbxproj
@@ -524,7 +524,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.piwik.PiwikTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx tvos";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 			};
@@ -546,7 +546,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.piwik.PiwikTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx tvos";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos macosx";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;

--- a/PiwikTracker/Device.swift
+++ b/PiwikTracker/Device.swift
@@ -132,6 +132,7 @@ internal struct Device {
     
 }
 #if os(OSX)
+    import AppKit
     extension Device {
         /// Reaturns the version number of the current OS as String i.e. "1.2" or "9.4"
         internal static func osVersionForCurrentDevice() -> String  {

--- a/PiwikTracker/Event.swift
+++ b/PiwikTracker/Event.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 /// Represents an event of any kind.
 ///

--- a/PiwikTracker/PiwikTracker.h
+++ b/PiwikTracker/PiwikTracker.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 PIWIK. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import Foundation;
 
 //! Project version number for PiwikTracker.
 FOUNDATION_EXPORT double PiwikTrackerVersionNumber;

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,19 @@ namespace :test do
   end
 end
 
+namespace :package_manager do
+  desc 'Prepare tests'
+  task :prepare do
+  end
+
+  desc 'Builds the project with Carthage'
+  task carthage: :prepare do
+    sh("carthage build --no-skip-current") rescue nil
+    package_manager_failed('Carthage integration') unless $?.success?
+  end
+end
+
+
 desc 'Run the PiwikTracker tests for iOS & Mac OS X'
 task :test do
   Rake::Task['test:ios'].invoke
@@ -40,7 +53,13 @@ task :test do
   Rake::Task['test:tvos_demo'].invoke
 end
 
+desc 'Check the integration of PiwikTracker with package managers'
+task :build_with_package_manager do
+  Rake::Task['package_manager:carthage'].invoke
+end
+
 task default: 'test'
+
 
 private
 
@@ -64,6 +83,11 @@ end
 
 def tests_failed(platform)
   puts red("#{platform} unit tests failed")
+  exit $?.exitstatus
+end
+
+def package_manager_failed(package_manager)
+  puts red("Integration with #{package_manager} failed")
   exit $?.exitstatus
 end
 


### PR DESCRIPTION
This attempts to fix #74 by solving a few build errors that happen when building with `carthage --no-skip-current`.

Theoretically, that should allow projects managed with Carthage to use the framework.