### PR TITLE
Create user agent on main queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* **improvement** The PiwikTracker is now save to create in a background thread. [#175](https://github.com/piwik/piwik-sdk-ios/pull/175)
+
 ## 4.3.0
 * **feature** Added the ability to send custom events with custom tracking parameters. [#153](https://github.com/piwik/piwik-sdk-ios/issues/153)
 * **bugfix** Fixed a crash when initializing a new tracker. [#162](https://github.com/piwik/piwik-sdk-ios/issues/162)

--- a/PiwikTracker.xcodeproj/project.pbxproj
+++ b/PiwikTracker.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		1F6F0CDE1E61E377008170FC /* TrackerFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6F0CDA1E61E377008170FC /* TrackerFixtures.swift */; };
 		1F6F0CDF1E61E377008170FC /* TrackerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6F0CDB1E61E377008170FC /* TrackerSpec.swift */; };
 		1F6F0CE11E61E4F3008170FC /* URLSessionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6F0CE01E61E4F3008170FC /* URLSessionDispatcher.swift */; };
+		1F7C667F1F8C096F0066CC64 /* MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7C667E1F8C096F0066CC64 /* MainThread.swift */; };
 		1F80856F1E6B4B9800A61AAF /* Locale+HttpAcceptLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F80856E1E6B4B9800A61AAF /* Locale+HttpAcceptLanguage.swift */; };
 		1FCA6D451DBE0B2F0033F01C /* PiwikTracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCA6D3B1DBE0B2F0033F01C /* PiwikTracker.framework */; };
 		1FCA6D4C1DBE0B2F0033F01C /* PiwikTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FCA6D3E1DBE0B2F0033F01C /* PiwikTracker.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -61,6 +62,7 @@
 		1F6F0CDA1E61E377008170FC /* TrackerFixtures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackerFixtures.swift; sourceTree = "<group>"; };
 		1F6F0CDB1E61E377008170FC /* TrackerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackerSpec.swift; sourceTree = "<group>"; };
 		1F6F0CE01E61E4F3008170FC /* URLSessionDispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionDispatcher.swift; sourceTree = "<group>"; };
+		1F7C667E1F8C096F0066CC64 /* MainThread.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainThread.swift; sourceTree = "<group>"; };
 		1F80856E1E6B4B9800A61AAF /* Locale+HttpAcceptLanguage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Locale+HttpAcceptLanguage.swift"; sourceTree = "<group>"; };
 		1FCA6D3B1DBE0B2F0033F01C /* PiwikTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PiwikTracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FCA6D3E1DBE0B2F0033F01C /* PiwikTracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PiwikTracker.h; sourceTree = "<group>"; };
@@ -157,6 +159,7 @@
 				1F38EBF71EE568D10021FBF8 /* Logger.swift */,
 				1FDC917D1F1A65150046F506 /* Application.swift */,
 				1FDC917E1F1A65150046F506 /* Device.swift */,
+				1F7C667E1F8C096F0066CC64 /* MainThread.swift */,
 				1FCA6D3F1DBE0B2F0033F01C /* Info.plist */,
 				1FCA6D3E1DBE0B2F0033F01C /* PiwikTracker.h */,
 			);
@@ -375,6 +378,7 @@
 				1F092C1A1E26B44500394B30 /* Dispatcher.swift in Sources */,
 				1F38EBF81EE568D10021FBF8 /* Logger.swift in Sources */,
 				1FCFF0241F82C7A50038BC17 /* CustomDimension.swift in Sources */,
+				1F7C667F1F8C096F0066CC64 /* MainThread.swift in Sources */,
 				1F80856F1E6B4B9800A61AAF /* Locale+HttpAcceptLanguage.swift in Sources */,
 				1F0A15CE1E6335D800FEAE72 /* Visitor.swift in Sources */,
 				1FDC917F1F1A65150046F506 /* Application.swift in Sources */,

--- a/PiwikTracker/MainThread.swift
+++ b/PiwikTracker/MainThread.swift
@@ -3,7 +3,3 @@ import Foundation
 func assetMainThread(_ file: StaticString = #file, line: UInt = #line) {
     assert(Thread.isMainThread, "\(file):\(line) must run on the main thread!")
 }
-
-public func asyncMain(_ block: @escaping () -> ()) {
-    DispatchQueue.main.async(execute: block)
-}

--- a/PiwikTracker/MainThread.swift
+++ b/PiwikTracker/MainThread.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+func assetMainThread(_ file: StaticString = #file, line: UInt = #line) {
+    assert(Thread.isMainThread, "\(file):\(line) must run on the main thread!")
+}
+
+public func asyncMain(_ block: @escaping () -> ()) {
+    DispatchQueue.main.async(execute: block)
+}

--- a/PiwikTracker/PiwikTracker.swift
+++ b/PiwikTracker/PiwikTracker.swift
@@ -69,6 +69,8 @@ final public class PiwikTracker: NSObject {
     ///   - baseURL: The url of the piwik server. This url has to end in `piwik.php`.
     ///   - userAgent: An optional parameter for custom user agent.
     convenience public init(siteId: String, baseURL: URL, userAgent: String? = nil) {
+        assert(baseURL.absoluteString.hasSuffix("piwik.php"), "The baseURL is expected to end in piwik.php")
+        
         let queue = MemoryQueue()
         let dispatcher = URLSessionDispatcher(baseURL: baseURL, userAgent: userAgent)
         self.init(siteId: siteId, queue: queue, dispatcher: dispatcher)

--- a/PiwikTracker/URLSessionDispatcher.swift
+++ b/PiwikTracker/URLSessionDispatcher.swift
@@ -23,7 +23,7 @@ final class URLSessionDispatcher: Dispatcher {
         self.baseURL = baseURL
         self.timeout = 5
         self.session = URLSession.shared
-        asyncMain {
+        DispatchQueue.main.async {
             self.userAgent = userAgent ?? URLSessionDispatcher.defaultUserAgent()
         }
     }

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ PiwikTracker.shared?.logger = DefaultLogger(minLevel: .error)
 You can also write your own `Logger` and send the logs whereever you want. Just write a new class/struct an let it conform to the `Logger` protocol.
 
 ### Custom User Agent
-The `PiwikTracker` will create a default user agent derived from the WKWebView user agent. This is why you should always instantiate and configure the `PiwikTracker` on the main thread.
+The `PiwikTracker` will create a default user agent derived from the WKWebView user agent.
 You can instantiate the `PiwikTracker` using your own user agent.
 
 ```


### PR DESCRIPTION
## What is new

* Create user agent on main queue
* Refactor duplicate code into common method

## How to test

Run the unit tests
Start and run the test application

## Known problems and limitations
`URLSessionDispatcher` is still not 100% thread safe since we are potentially creating and accessing `userAgent` on different threads. 

I think the best solution would be to always create `URLSessionDispatcher` on the main queue, this will also allow `userAgent` to be declared `let`. But this would require synchronisation in the `PiwikTracker` when creating and accessing the dispatcher, this is probably a necessary change anyway since the `PiwikTracker` is not fully thread safe today.