### PR TITLE
Removed the url as required parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * **feature** Added a way to add custom dimension in the action scope. [#111](https://github.com/piwik/piwik-sdk-ios/issues/111)
 * **improvement** The PiwikTracker is now save to create in a background thread. [#175](https://github.com/piwik/piwik-sdk-ios/pull/175)
 * **improvement** The Logger is now objc compatible. [#185](https://github.com/piwik/piwik-sdk-ios/issues/185)
+* **improvement** Default `example.com` urls aren't generated anymore. [#194](https://github.com/piwik/piwik-sdk-ios/pull/195)
 
 ## 4.3.0
 * **feature** Added the ability to send custom events with custom tracking parameters. [#153](https://github.com/piwik/piwik-sdk-ios/issues/153)

--- a/Example/ios/iOS Example/ObjectiveCCompatibilityChecker.m
+++ b/Example/ios/iOS Example/ObjectiveCCompatibilityChecker.m
@@ -7,9 +7,13 @@
 - (void)check {
     [PiwikTracker configureSharedInstanceWithSiteID:@"5" baseURL:[NSURL URLWithString:@"http://example.com/piwik.php"] userAgent:nil];
     [[PiwikTracker shared] trackWithView:@[@"example"] url:nil];
-    [[PiwikTracker shared] trackWithEventWithCategory:@"category" action:@"action" name:nil number:nil];
+    [[PiwikTracker shared] trackWithEventWithCategory:@"category" action:@"action" name:nil number:nil url:nil];
     [[PiwikTracker shared] dispatch];
     [PiwikTracker shared].logger = [[DefaultLogger alloc] initWithMinLevel:LogLevelVerbose];
+}
+
+- (void)checkDeprecated {
+    [[PiwikTracker shared] trackWithEventWithCategory:@"category" action:@"action" name:nil number:nil];
 }
 
 @end

--- a/PiwikTracker/Event.swift
+++ b/PiwikTracker/Event.swift
@@ -37,7 +37,7 @@ public struct Event {
     
     /// The full URL for the current action. 
     /// api-key: url
-    let url: URL
+    let url: URL?
     
     /// api-key: action_name
     let actionName: [String]
@@ -72,7 +72,6 @@ public struct Event {
 
 extension Event {
     public init(tracker: PiwikTracker, action: [String], url: URL? = nil, referer: URL? = nil, eventCategory: String? = nil, eventAction: String? = nil, eventName: String? = nil, eventValue: Float? = nil, customTrackingParameters: [String:String] = [:], dimensions: [CustomDimension] = []) {
-        let url = url ?? URL(string: "http://example.com")!.appendingPathComponent(action.joined(separator: "/"))
         self.siteId = tracker.siteId
         self.uuid = NSUUID()
         self.visitor = tracker.visitor

--- a/PiwikTracker/MainThread.swift
+++ b/PiwikTracker/MainThread.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-func assetMainThread(_ file: StaticString = #file, line: UInt = #line) {
+func assertMainThread(_ file: StaticString = #file, line: UInt = #line) {
     assert(Thread.isMainThread, "\(file):\(line) must run on the main thread!")
 }

--- a/PiwikTracker/PiwikTracker.swift
+++ b/PiwikTracker/PiwikTracker.swift
@@ -222,7 +222,7 @@ extension PiwikTracker {
     /// This method can be used to track hierarchical screen names, e.g. screen/settings/register. Use this to create a hierarchical and logical grouping of screen views in the Piwik web interface.
     ///
     /// - Parameter view: An array of hierarchical screen names.
-    /// - Parameter url: The url of the page that was viewed. If none set the url will be http://example.com appended by the screen segments. Example: http://example.com/players/john-appleseed
+    /// - Parameter url: The optional url of the page that was viewed.
     /// - Parameter dimensions: An optional array of dimensions, that will be set only in the scope of this view.
     public func track(view: [String], url: URL? = nil, dimensions: [CustomDimension] = []) {
         let event = Event(tracker: self, action: view, url: url, dimensions: dimensions)
@@ -239,8 +239,9 @@ extension PiwikTracker {
     ///   - name: The optional name of the Event
     ///   - value: The optional value of the Event
     ///   - dimensions: An optional array of dimensions, that will be set only in the scope of this event.
-    public func track(eventWithCategory category: String, action: String, name: String? = nil, value: Float? = nil, dimensions: [CustomDimension] = []) {
-        let event = Event(tracker: self, action: [], eventCategory: category, eventAction: action, eventName: name, eventValue: value, dimensions: dimensions)
+    ///   - url: The optional url of the page that was viewed.
+    public func track(eventWithCategory category: String, action: String, name: String? = nil, value: Float? = nil, dimensions: [CustomDimension] = [], url: URL? = nil) {
+        let event = Event(tracker: self, action: [], url: url, eventCategory: category, eventAction: action, eventName: name, eventValue: value, dimensions: dimensions)
         queue(event: event)
     }
 }
@@ -292,9 +293,14 @@ extension PiwikTracker {
         track(view: view, url: url, dimensions: [])
     }
     
-    @objc public func track(eventWithCategory category: String, action: String, name: String? = nil, number: NSNumber? = nil) {
+    @objc public func track(eventWithCategory category: String, action: String, name: String? = nil, number: NSNumber? = nil, url: URL? = nil) {
         let value = number == nil ? nil : number!.floatValue
-        track(eventWithCategory: category, action: action, name: name, value: value)
+        track(eventWithCategory: category, action: action, name: name, value: value, url: url)
+    }
+    
+    @available(*, deprecated, message: "use trackEventWithCategory:action:name:number:url instead")
+    @objc public func track(eventWithCategory category: String, action: String, name: String? = nil, number: NSNumber? = nil) {
+        track(eventWithCategory: category, action: action, name: name, number: number, url: nil)
     }
 }
 

--- a/PiwikTracker/URLSessionDispatcher.swift
+++ b/PiwikTracker/URLSessionDispatcher.swift
@@ -29,7 +29,7 @@ final class URLSessionDispatcher: Dispatcher {
     }
     
     private static func defaultUserAgent() -> String {
-        assetMainThread()
+        assertMainThread()
         #if os(OSX)
             let webView = WebView(frame: .zero)
             let currentUserAgent = webView.stringByEvaluatingJavaScript(from: "navigator.userAgent") ?? ""
@@ -108,7 +108,7 @@ fileprivate extension Event {
                 URLQueryItem(name: "_viewts", value: "\(Int(session.lastVisit.timeIntervalSince1970))"),
                 URLQueryItem(name: "_idts", value: "\(Int(session.firstVisit.timeIntervalSince1970))"),
                 
-                URLQueryItem(name: "url", value:url.absoluteString),
+                URLQueryItem(name: "url", value:url?.absoluteString),
                 URLQueryItem(name: "action_name", value: actionName.joined(separator: "/")),
                 URLQueryItem(name: "lang", value: language),
                 URLQueryItem(name: "urlref", value: referer?.absoluteString),


### PR DESCRIPTION
Fixes/Implements #194

What changed:

- The url parameter of an `Event` is now an optional parameter
- The convenience methods for view and event tracking have a new optional url parameter
- When not defining a url, no default url will be generated

Do we want to add a way to generate a default url? If so, this would be my proposal:

- Add a new property `contentBaseUrl` to the PiwikTracker
- If this property is set, every event that has no url set will generate one by its own
- To generate a url, it will use the `contentBaseUrl` and append the action-array as path

Example:
- `contentBaseUrl` is https://piwik.org
- actions is ["docs", "requirements"]
- the url will be https://piwik.org/docs/requirements