### PR TITLE
Fix a couple Swift 4 complaints

### DIFF
--- a/PiwikTracker/Visitor.swift
+++ b/PiwikTracker/Visitor.swift
@@ -38,6 +38,6 @@ extension Visitor {
         let sanitizedUUID = uuid.replacingOccurrences(of: "-", with: "")
         let start = sanitizedUUID.startIndex
         let end = sanitizedUUID.index(start, offsetBy: 16)
-        return sanitizedUUID.substring(with: start..<end)
+        return String(sanitizedUUID[start..<end])
     }
 }


### PR DESCRIPTION
* Fix warning: "'substring(with:)' is deprecated: Please use String slicing subscript."
* Fix subsequent error: "Subscripts returning String were obsoleted in Swift 4; explicitly construct a String from subscripted result."