### PR TITLE
The swift version of xcode 9.3 is 4.1.

### DIFF
--- a/MatomoTracker/MatomoTracker.swift
+++ b/MatomoTracker/MatomoTracker.swift
@@ -19,7 +19,7 @@ final public class MatomoTracker: NSObject {
     
     /// Will be used to associate all future events with a given userID. This property
     /// is persisted between app launches.
-    public var visitorId: String? {
+    @objc public var visitorId: String? {
         get {
             return matomoUserDefaults.visitorUserId
         }


### PR DESCRIPTION
The swift version of xcode 9.3 is 4.1. When using oc to call the visitorId value of matomoTracker, you need to add @objc to the visitorId.