### PR TITLE
Replaced generic phone model by device model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.1.2
+* **bugfix** Replaced generic phone model by device model. [#254](https://github.com/matomo-org/matomo-sdk-ios/pull/253)
+
 ## 5.1.1
 * **bugfix** Fixed Xcode build settings for Carthage support. [#224](https://github.com/matomo-org/matomo-sdk-ios/pull/244) (by @phranck)
 

--- a/MatomoTracker/URLSessionDispatcher.swift
+++ b/MatomoTracker/URLSessionDispatcher.swift
@@ -36,7 +36,16 @@ final class URLSessionDispatcher: Dispatcher {
             let currentUserAgent = webView.stringByEvaluatingJavaScript(from: "navigator.userAgent") ?? ""
         #elseif os(iOS)
             let webView = UIWebView(frame: .zero)
-            let currentUserAgent = webView.stringByEvaluatingJavaScript(from: "navigator.userAgent") ?? ""
+            var currentUserAgent = webView.stringByEvaluatingJavaScript(from: "navigator.userAgent") ?? ""
+            if let regex = try? NSRegularExpression(pattern: "\\((iPad|iPhone);", options: .caseInsensitive) {
+                let deviceModel = Device.makeCurrentDevice().platform
+                currentUserAgent = regex.stringByReplacingMatches(
+                    in: currentUserAgent,
+                    options: .withTransparentBounds,
+                    range: NSRange(location: 0, length: currentUserAgent.count),
+                    withTemplate: "(\(deviceModel);"
+                )
+            }
         #elseif os(tvOS)
             let currentUserAgent = ""
         #endif


### PR DESCRIPTION
For android devices we see the specific device model in the backend, for iOS devices we only see generic "iPad" or "iPhone".
Here we replace the generic string in the user agent with the real device model (e.g. iPhone8,4),  which lets the backend properly display "iPhone SE".