### PR TITLE
Specify Swift 4.2 in podspecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * **improvement** Made copyFromOldSharedInstance available from Objective-C. [#282] (https://github.com/matomo-org/matomo-sdk-ios/issues/282)
 * **improvement** Accepting urls ending in `matomo.php` in addition to `piwik.php` when initializing a new instance. [#286] (https://github.com/matomo-org/matomo-sdk-ios/pull/286)
+* **bugfix**  Specified Swift 4.2 in both `.podspec` files. [#297] (https://github.com/matomo-org/matomo-sdk-ios/pull/297)
 
 ## 6.0.0
 * **feature** Added the possibility to implement custom queues. [#137](https://github.com/matomo-org/matomo-sdk-ios/issues/137)

--- a/MatomoTracker.podspec
+++ b/MatomoTracker.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |spec|
   spec.osx.deployment_target = '10.12'
   spec.requires_arc = true
   spec.default_subspecs = 'Core'
+  spec.swift_version = '4.2'
   
   spec.subspec 'Core' do |core|
   	core.source_files = 'MatomoTracker/*.swift'

--- a/PiwikTracker.podspec
+++ b/PiwikTracker.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
   spec.osx.deployment_target = '10.12'
   spec.requires_arc = true
   spec.default_subspecs = 'Core'
-  spec.swift_version = '4.1'
+  spec.swift_version = '4.2'
   
   spec.deprecated_in_favor_of = 'MatomoTracker'
   


### PR DESCRIPTION
Hiya 👋!

I bumped my project to Swift 5, and started getting some classic "this isn't Swift 5" errors:

```
Add () to forward @autoclosure parameter
```

Looking into the podspec, `PiwikTracker.podspec` [specifies Swift 4.1](https://github.com/matomo-org/matomo-sdk-ios/blob/be29a82d921a101a3ddd358b660b3da5e1b2a296/PiwikTracker.podspec#L14) (via #267, #260), but `MatomoTracker.podspec` doesn't mention anything at all. Meanwhile `.swift-version` [specifies Swift 4.2](https://github.com/matomo-org/matomo-sdk-ios/blob/be29a82d921a101a3ddd358b660b3da5e1b2a296/.swift-version#L1).

This PR brings them all into line as Swift 4.2 consistently.

And just in case anyone else is having issues, here's the workaround in your `Podfile` until this is published:

```rb
post_install do |installer|
  swifts = {
    'MatomoTracker' => '4.2'
    # ...specify any other Pods with Swift 4.x requirements here if necessary
  }

  installer.pods_project.targets.each do |target|
    target.build_configurations.each do |config|
      config.build_settings['SWIFT_VERSION'] = swifts[target.name] if swifts.has_key?(target.name)
    end
  end
end
```