### PR TITLE
Adds `cdt` parameter to tracking query items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* **improvement** Added `cdt` query item in addition to `h`/`m`/`s` values [#301] (https://github.com/matomo-org/matomo-sdk-ios/pull/301)
 * **improvement** Updated to Swift 5.0 and Xcode 10.3 tools version. [#306](https://github.com/matomo-org/matomo-sdk-ios/pull/306)
 * **change** Dropped support for iOS 8 and 9. [#306](https://github.com/matomo-org/matomo-sdk-ios/pull/306)
 

--- a/MatomoTracker/EventAPISerializer.swift
+++ b/MatomoTracker/EventAPISerializer.swift
@@ -61,7 +61,7 @@ fileprivate extension Event {
                 URLQueryItem(name: "m", value: DateFormatter.minuteDateFormatter.string(from: date)),
                 URLQueryItem(name: "s", value: DateFormatter.secondsDateFormatter.string(from: date)),
 
-                URLQueryItem(name: "cdt", value: DateFormatter.utcDateTimeFormatter.string(from: date)),
+                URLQueryItem(name: "cdt", value: DateFormatter.iso8601DateFormatter.string(from: date)),
                 
                 //screen resolution
                 URLQueryItem(name: "res", value:String(format: "%1.0fx%1.0f", screenResolution.width, screenResolution.height)),
@@ -121,18 +121,28 @@ fileprivate extension DateFormatter {
         dateFormatter.dateFormat = "ss"
         return dateFormatter
     }()
-
-    // Note: this is ISO 8601-ish, but not quite.
-    // Example from docs (i.e. for `cdt`) looks like: "2011-04-05 00:11:42"
-    static let utcDateTimeFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.calendar = Calendar(identifier: .iso8601)
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.timeZone = TimeZone(identifier: "UTC")
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return dateFormatter
+    static let iso8601DateFormatter: DateFormatterProtocol = {
+        if #available(iOS 10, OSX 10.12, watchOS 3.0, tvOS 10.0, *) {
+            return ISO8601DateFormatter()
+        } else {
+            let formatter = DateFormatter()
+            formatter.calendar = Calendar(identifier: .iso8601)
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "UTC")
+            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+            return formatter
+        }
     }()
 }
+
+fileprivate protocol DateFormatterProtocol {
+    func string(from date: Date) -> String
+    func date(from string: String) -> Date?
+}
+
+@available(iOS 10, OSX 10.12, watchOS 3.0, tvOS 10.0, *)
+extension ISO8601DateFormatter: DateFormatterProtocol {}
+extension DateFormatter: DateFormatterProtocol {}
 
 fileprivate extension CharacterSet {
     

--- a/MatomoTracker/EventAPISerializer.swift
+++ b/MatomoTracker/EventAPISerializer.swift
@@ -60,6 +60,8 @@ fileprivate extension Event {
                 URLQueryItem(name: "h", value: DateFormatter.hourDateFormatter.string(from: date)),
                 URLQueryItem(name: "m", value: DateFormatter.minuteDateFormatter.string(from: date)),
                 URLQueryItem(name: "s", value: DateFormatter.secondsDateFormatter.string(from: date)),
+
+                URLQueryItem(name: "cdt", value: DateFormatter.utcDateTimeFormatter.string(from: date)),
                 
                 //screen resolution
                 URLQueryItem(name: "res", value:String(format: "%1.0fx%1.0f", screenResolution.width, screenResolution.height)),
@@ -117,6 +119,17 @@ fileprivate extension DateFormatter {
     static let secondsDateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "ss"
+        return dateFormatter
+    }()
+
+    // Note: this is ISO 8601-ish, but not quite.
+    // Example from docs (i.e. for `cdt`) looks like: "2011-04-05 00:11:42"
+    static let utcDateTimeFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.calendar = Calendar(identifier: .iso8601)
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(identifier: "UTC")
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         return dateFormatter
     }()
 }


### PR DESCRIPTION
Because of ✨reasons✨, the `h`/`m`/`s` values don't seem to be used in calculating "time on page" in the backend, but `cdt` does.

This PR attaches `cdt` to the tracking events in addition to the existing `h`/`m`/`s` values.

According to [this issue](https://forum.matomo.org/t/api-time-on-page-time-spent-ref-action-has-0-values/16456), `cdt` will be used to calculate the "time on page" correctly for the clients, regardless of when they're sent to the server

~According to [these docs](https://developer.matomo.org/api-reference/tracking-api#other-parameters-require-authentication-via-token_auth), the format is `yyyy-MM-dd HH:mm:ss` (i.e. `2011-04-05 00:11:42`) - not quite ISO-8601, but close (although we could use a unix timestamp? They're always a little harder to grok for human eyes though). _However_ (and this is an implementation detail, so probably best to ignore or update docs), the server uses unix timestamp internally, and processes it [via `strtotime()`](https://github.com/matomo-org/matomo/blob/417c91f446624043a078c5b2d3378decbb9d86cd/core/Tracker/Request.php#L483-L485), so we _could_ use a formal ISO 8601 date string here if we'd prefer.~ ➡️ Using ISO 8601 format since 2feaae1

---

Resolves #299 