### PR TITLE
Specify cookies for authenticated communication with Matomo APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.0.2
+* **feature** Specify cookies for authenticated communication with Matomo APIs
+
 ## 6.0.1
 * **improvement** Made copyFromOldSharedInstance available from Objective-C. [#282] (https://github.com/matomo-org/matomo-sdk-ios/issues/282)
 * **improvement** Accepting urls ending in `matomo.php` in addition to `piwik.php` when initializing a new instance. [#286] (https://github.com/matomo-org/matomo-sdk-ios/pull/286)

--- a/Example/ios/iOS Example/MatomoTracker+SharedInstance.swift
+++ b/Example/ios/iOS Example/MatomoTracker+SharedInstance.swift
@@ -6,6 +6,8 @@ extension MatomoTracker {
         let queue = UserDefaultsQueue(UserDefaults.standard, autoSave: true)
         let dispatcher = URLSessionDispatcher(baseURL: URL(string: "https://demo2.matomo.org/piwik.php")!)
         let matomoTracker = MatomoTracker(siteId: "23", queue: queue, dispatcher: dispatcher)
+        // matomoTracker.userId = "userId"
+        // matomoTracker.setCookie(cookie: "cookie1=value1; cookie2=value2")
         matomoTracker.logger = DefaultLogger(minLevel: .info)
         matomoTracker.migrateFromFourPointFourSharedInstance()
         return matomoTracker

--- a/MatomoTracker.podspec
+++ b/MatomoTracker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "MatomoTracker"
-  spec.version      = "6.0.1"
+  spec.version      = "6.0.2"
   spec.summary      = "A Matomo Tracker written in Swift for iOS, tvOS and macOS apps."
   spec.homepage     = "https://github.com/matomo-org/matomo-sdk-ios/"
   spec.license      = { :type => 'MIT', :file => 'LICENSE.md' }

--- a/MatomoTracker/Dispatcher.swift
+++ b/MatomoTracker/Dispatcher.swift
@@ -6,5 +6,7 @@ public protocol Dispatcher {
     
     var userAgent: String? { get }
     
+    var cookie: String? { get set }
+    
     func send(events: [Event], success: @escaping ()->(), failure: @escaping (_ error: Error)->())
 }

--- a/MatomoTracker/MatomoTracker.swift
+++ b/MatomoTracker/MatomoTracker.swift
@@ -250,6 +250,11 @@ final public class MatomoTracker: NSObject {
     @objc public func trackContentInteraction(name: String, interaction: String, piece: String?, target: String?) {
         track(Event(tracker: self, action: [], contentName: name, contentInteraction: interaction, contentPiece: piece, contentTarget: target))
     }
+
+    public func setCookie(cookie: String?) {
+        var dispatcher = self.dispatcher
+        dispatcher.cookie = cookie
+    }
 }
 
 extension MatomoTracker {

--- a/MatomoTracker/URLSessionDispatcher.swift
+++ b/MatomoTracker/URLSessionDispatcher.swift
@@ -12,6 +12,7 @@ public final class URLSessionDispatcher: Dispatcher {
     private let timeout: TimeInterval
     private let session: URLSession
     public let baseURL: URL
+    public var cookie: String?
 
     public private(set) var userAgent: String?
     
@@ -66,6 +67,9 @@ public final class URLSessionDispatcher: Dispatcher {
     
     private func buildRequest(baseURL: URL, method: String, contentType: String? = nil, body: Data? = nil) -> URLRequest {
         var request = URLRequest(url: baseURL, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: timeout)
+        if (self.cookie != nil) {
+            request.setValue(self.cookie, forHTTPHeaderField: "Cookie")
+        }
         request.httpMethod = method
         body.map { request.httpBody = $0 }
         contentType.map { request.setValue($0, forHTTPHeaderField: "Content-Type") }


### PR DESCRIPTION
We have a case, when we set up our own Matomo API and it has to be behind a corporate proxy. Our mobile app performs authentication, but Matomo communication did not use generated cookies. As a result, no request to the API was possible and no statistics were sent. I've added a way to provide cookies for use in that communication.
While this is a niche case, the modification is small and it may be of use to somebody else.