### PR TITLE
Added `@escaping` attributes to the Queue protocol's functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.0.2
+
+* **improvement** Allow to use the Queue's completions in asynchronous scope.
+
 ## 6.0.1
 * **improvement** Made copyFromOldSharedInstance available from Objective-C. [#282] (https://github.com/matomo-org/matomo-sdk-ios/issues/282)
 * **improvement** Accepting urls ending in `matomo.php` in addition to `piwik.php` when initializing a new instance. [#286] (https://github.com/matomo-org/matomo-sdk-ios/pull/286)

--- a/MatomoTracker/EventAPISerializer.swift
+++ b/MatomoTracker/EventAPISerializer.swift
@@ -124,7 +124,7 @@ fileprivate extension DateFormatter {
 fileprivate extension CharacterSet {
     
     /// Returns the character set for characters allowed in a query parameter URL component.
-    fileprivate static var urlQueryParameterAllowed: CharacterSet {
+    static var urlQueryParameterAllowed: CharacterSet {
         return CharacterSet.urlQueryAllowed.subtracting(CharacterSet(charactersIn: "&/?"))
     }
 }

--- a/MatomoTracker/MatomoTracker.swift
+++ b/MatomoTracker/MatomoTracker.swift
@@ -167,7 +167,8 @@ final public class MatomoTracker: NSObject {
             }
             return
         }
-        queue.first(limit: numberOfEventsDispatchedAtOnce) { events in
+        queue.first(limit: numberOfEventsDispatchedAtOnce) { [weak self] events in
+            guard let self = self else { return }
             guard events.count > 0 else {
                 // there are no more events queued, finish dispatching
                 self.isDispatching = false
@@ -175,7 +176,8 @@ final public class MatomoTracker: NSObject {
                 self.logger.info("Finished dispatching events")
                 return
             }
-            self.dispatcher.send(events: events, success: {
+            self.dispatcher.send(events: events, success: { [weak self] in
+                guard let self = self else { return }
                 DispatchQueue.main.async {
                     self.queue.remove(events: events, completion: {
                         self.logger.info("Dispatched batch of \(events.count) events.")
@@ -184,7 +186,8 @@ final public class MatomoTracker: NSObject {
                         }
                     })
                 }
-            }, failure: { error in
+            }, failure: { [weak self] error in
+                guard let self = self else { return }
                 self.isDispatching = false
                 self.startDispatchTimer()
                 self.logger.warning("Failed dispatching events with error \(error)")

--- a/MatomoTracker/Queue.swift
+++ b/MatomoTracker/Queue.swift
@@ -4,17 +4,17 @@ public protocol Queue {
     
     var eventCount: Int { get }
     
-    mutating func enqueue(events: [Event], completion: (()->())?)
+    mutating func enqueue(events: [Event], completion: (()-> Void)?)
     
     /// Returns the first `limit` events ordered by Event.date
-    func first(limit: Int, completion: (_ items: [Event])->())
+    func first(limit: Int, completion: @escaping (_ items: [Event]) -> Void)
     
     /// Removes the events from the queue
-    mutating func remove(events: [Event], completion: ()->())
+    mutating func remove(events: [Event], completion: @escaping () -> Void)
 }
 
 extension Queue {
-    mutating func enqueue(event: Event, completion: (()->())? = nil) {
+    mutating func enqueue(event: Event, completion: (()->Void)? = nil) {
         enqueue(events: [event], completion: completion)
     }
 }


### PR DESCRIPTION
This fix allows calling completions of the Queue protocol's functions from an asynchronous scope.
For example, the Queue's functions calling on the Main thread, but processing of arguments required background queue.

I have also fixed a Xcode warning.