### PR TITLE
Fix for broken builds in macOS #trivial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ install:
   - pod install || pod install --repo-update
 
 script:
-  # These exports are a workaround for a cocoapod issue: https://github.com/CocoaPods/CocoaPods/issues/7708
-  - export EXPANDED_CODE_SIGN_IDENTITY=""
-  - export EXPANDED_CODE_SIGN_IDENTITY_NAME=""
-  - export EXPANDED_PROVISIONING_PROFILE=""
   - rake test
   - rake build_with_package_manager
 

--- a/MatomoTracker.xcodeproj/xcshareddata/xcschemes/MatomoTracker.xcscheme
+++ b/MatomoTracker.xcodeproj/xcshareddata/xcschemes/MatomoTracker.xcscheme
@@ -55,6 +55,15 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1FCA6D3A1DBE0B2F0033F01C"
+            BuildableName = "MatomoTracker.framework"
+            BlueprintName = "MatomoTracker"
+            ReferencedContainer = "container:MatomoTracker.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/MatomoTracker.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/MatomoTracker.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
[Apparently](https://github.com/CocoaPods/CocoaPods/issues/8729) there is a [bug](https://openradar.appspot.com/20490378) on Xcode 10.2 and 10.3 where, using Implicit Dependencies, those might sometimes not match.

In this PR I changed over to the Legacy Build System. We might want to check this again on Xcode 11