### PR TITLE
Fix validation of a forcedVisitorId value by using unsigned int type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.0.1
+
+* **bugfix** Fixed an issue with a new `forcedVisitorId` value validation.
+
 ## 7.0.0
 * **important** Dropped support for iOS 8 and 9. [#306](https://github.com/matomo-org/matomo-sdk-ios/pull/306)
 * **improvement** Updated to Swift 5.0 and Xcode 10.3 tools version. [#306](https://github.com/matomo-org/matomo-sdk-ios/pull/306)

--- a/MatomoTracker/MatomoTracker.swift
+++ b/MatomoTracker/MatomoTracker.swift
@@ -50,7 +50,7 @@ final public class MatomoTracker: NSObject {
         set {
             logger.debug("Setting the forcedVisitorId to \(forcedVisitorId ?? "nil")")
             if let newValue = newValue {
-                let isValidString = Int(newValue, radix: 16) != nil && newValue.count == 16
+                let isValidString = UInt64(newValue, radix: 16) != nil && newValue.count == 16
                 if isValidString {
                     matomoUserDefaults.forcedVisitorId = newValue
                 } else {


### PR DESCRIPTION
Found that setting a `forcedVisitorId` with the hex values of more than "7999999999999999" cannot be valid in the current implementation. The solution is just to use `UInt64` instead of `Int`.

Example:
```swift
var a = "7999999999999999"
var b = "8000000000000000"

Int(a, radix: 16) /// Value is 8762203435012037017
UInt64(a, radix: 16) /// Value is 8762203435012037017


Int(b, radix: 16) /// Value is nil
UInt64(b, radix: 16) /// Value is 9223372036854775808
```