### PR TITLE
Added timeout property to URLSessionDispatcher init method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.0.2 
+* **improvement** Added `timeout` property to URLSessionDispatcher initialization method
+
 ## 7.0.1
 * **bugfix** Fixed an issue with a new `forcedVisitorId` value validation. [#315](https://github.com/matomo-org/matomo-sdk-ios/pull/315)
 

--- a/MatomoTracker/URLSessionDispatcher.swift
+++ b/MatomoTracker/URLSessionDispatcher.swift
@@ -20,9 +20,10 @@ public final class URLSessionDispatcher: Dispatcher {
     /// - Parameters:
     ///   - baseURL: The url of the Matomo server. This url has to end in `piwik.php`.
     ///   - userAgent: An optional parameter for custom user agent.
-    public init(baseURL: URL, userAgent: String? = nil) {                
+    ///   - timeout: The timeout interval for the request. The default is 5.0.
+    public init(baseURL: URL, userAgent: String? = nil, timeout: TimeInterval = 5.0) {
         self.baseURL = baseURL
-        self.timeout = 5
+        self.timeout = timeout
         self.session = URLSession.shared
         if let userAgent = userAgent {
             self.userAgent = userAgent


### PR DESCRIPTION
#### Description
Resolves  [#317](https://github.com/matomo-org/matomo-sdk-ios/issues/317)
In bad network conditions with 5 sec timeout many requests interrupts with timeout error.

#### Solution
Add timeout to URLSessionDispatcher init method
