### PR TITLE
Fixing a retain cycle on MatomoTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * **improvement** Added new devices info [#321](https://github.com/matomo-org/matomo-sdk-ios/pull/321)
 * **improvement** Added `timeout` property to URLSessionDispatcher initialization method
 * **bugfix** Fixed an issue with `WKWebView` on iOS not returning a user agent string [#322](https://github.com/matomo-org/matomo-sdk-ios/issues/322)
+* **bugfix** Fixed a retain cycle on `MatomoTracker`. [#316](https://github.com/matomo-org/matomo-sdk-ios/issues/316)
 
 ## 7.0.1
 * **bugfix** Fixed an issue with a new `forcedVisitorId` value validation. [#315](https://github.com/matomo-org/matomo-sdk-ios/pull/315)

--- a/MatomoTracker/MatomoTracker.swift
+++ b/MatomoTracker/MatomoTracker.swift
@@ -216,7 +216,11 @@ final public class MatomoTracker: NSObject {
             dispatchTimer.invalidate()
             self.dispatchTimer = nil
         }
-        self.dispatchTimer = Timer.scheduledTimer(timeInterval: dispatchInterval, target: self, selector: #selector(dispatch), userInfo: nil, repeats: false)
+        // Dispatchin asynchronous here to break the retain cycle
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.dispatchTimer = Timer.scheduledTimer(timeInterval: self.dispatchInterval, target: self, selector: #selector(self.dispatch), userInfo: nil, repeats: false)
+        }
     }
     
     internal var visitor: Visitor

--- a/MatomoTrackerTests/TrackerSpec.swift
+++ b/MatomoTrackerTests/TrackerSpec.swift
@@ -4,11 +4,15 @@ import Nimble
 
 class TrackerSpec: QuickSpec {
     override func spec() {
-        Nimble.AsyncDefaults.Timeout = 10
+        Nimble.AsyncDefaults.Timeout = 1
         describe("init") {
             it("should be able to initialized the MatomoTracker with a URL ending on `matomo.php`") {
                 let tracker = MatomoTracker(siteId: "5", baseURL: URL(string: "https://example.com/matomo.php")!)
                 expect(tracker).toNot(beNil())
+            }
+            it("should be released if no external strong reference exists (no retain cycles") {
+                weak var tracker = MatomoTracker(siteId: "5", baseURL: URL(string: "https://example.com/matomo.php")!)
+                expect(tracker).to(beNil())
             }
         }
         describe("queue") {
@@ -82,7 +86,7 @@ class TrackerSpec: QuickSpec {
                 }
                 trackerFixture.tracker.queue(event: EventFixture.event())
                 trackerFixture.tracker.dispatchInterval = 0.5
-                expect(numberOfDispatches).toEventually(equal(5))
+                expect(numberOfDispatches).toEventually(equal(5), timeout: 10)
             }
             it("should start a new DispatchTimer if dispatching succeeded") {
                 var numberOfDispatches = 0


### PR DESCRIPTION
This bug fixes #316 

The retain cycle exists, because the timer holds a strong reference of the tracker and the tracker holds a strong reference on the timer. This cycle is only broken when the timer is invalidated. That only happened in the `startDispatchTimer()` where right after it a new timer was started and thus self was retained again.

I broke the retain cycle by asynchronously dispatching the creation of the new timer and only keeping a weak reference to self in the meantime.