### PR TITLE
Retain `WKWebView` while executing JavaScript for User-Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 
+## Unreleased
+* **bugfix** Fixed an issue with `WKWebView` on iOS not returning a user agent string [#322](https://github.com/matomo-org/matomo-sdk-ios/issues/322)
+
 ## 7.0.3
 * **improvement** Added new devices info [#321](https://github.com/matomo-org/matomo-sdk-ios/pull/321)
 

--- a/MatomoTracker/URLSessionDispatcher.swift
+++ b/MatomoTracker/URLSessionDispatcher.swift
@@ -14,6 +14,10 @@ public final class URLSessionDispatcher: Dispatcher {
     public let baseURL: URL
 
     public private(set) var userAgent: String?
+
+    #if os(iOS)
+    private static var webView: WKWebView?
+    #endif
     
     /// Generate a URLSessionDispatcher instance
     ///
@@ -42,13 +46,15 @@ public final class URLSessionDispatcher: Dispatcher {
             let userAgent = webView.stringByEvaluatingJavaScript(from: "navigator.userAgent") ?? ""
             completion(userAgent.appending(useragentSuffix))
             #elseif os(iOS)
-            let webView = WKWebView(frame: .zero)
-            webView.evaluateJavaScript("navigator.userAgent") { (result, error) -> Void in
+            webView = WKWebView(frame: .zero)
+            webView?.evaluateJavaScript("navigator.userAgent") { (result, error) -> Void in
                 if let userAgent = result as? String {
                     completion(userAgent.appending(useragentSuffix))
                 } else {
                     completion(useragentSuffix)
                 }
+
+                webView = nil
             }
             #elseif os(tvOS)
             completion(useragentSuffix)


### PR DESCRIPTION
Fixes #322.

It seems like the `WKWebView` instance was going away while running the JS. The completion handler returned (I guess that's a separate `JSContext`?), but because the web view was gone, it would give us the following error:

```
Error Domain=WKErrorDomain Code=3 "The WKWebView was invalidated" UserInfo={NSLocalizedDescription=The WKWebView was invalidated}
```

So this amends #310 to return a value. Here's what the UAs look for me, out of the simulator:

Previous `UIWebView` version: 
```
"Mozilla/5.0 (x86_64; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MatomoTracker SDK URLSessionDispatcher"
```

`WKWebView` via #310:

```
" MatomoTracker SDK URLSessionDispatcher"`
```

(`error` was present, so it just returned the default suffix)

`WKWebView` via this PR: 

```
"Mozilla/5.0 (iPhone; CPU iPhone OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MatomoTracker SDK URLSessionDispatcher"
```

The only difference is `x86_64` vs `iPhone`, but that was previously being replaced manually (and was removed for a good reason?), so I think this should be ok now.