### PR TITLE
New session not starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,3 +113,4 @@
 * **feature** Tracking Events
 * **feature** URLSessionDispatcher
 * **feature** Non persistent Event Queue
+* **bugfix** Fixed bug, where new session not started manually [#325](https://github.com/matomo-org/matomo-sdk-ios/issues/325)

--- a/MatomoTracker/MatomoTracker.swift
+++ b/MatomoTracker/MatomoTracker.swift
@@ -268,6 +268,7 @@ extension MatomoTracker {
         matomoUserDefaults.previousVisit = matomoUserDefaults.currentVisit
         matomoUserDefaults.currentVisit = Date()
         matomoUserDefaults.totalNumberOfVisits += 1
+        nextEventStartsANewSession = true
         self.session = Session.current(in: matomoUserDefaults)
     }
 }


### PR DESCRIPTION
Fixing issue - https://github.com/matomo-org/matomo-sdk-ios/issues/325

Set nextEventStartsANewSession flag in ```MatomoTracker::startNewSession()``` to notify next event that new session started