### PR TITLE
Added back real device model in user agent feature 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* **improvement** Added back detailed phone model feature #253. [#330](https://github.com/matomo-org/matomo-sdk-ios/pull/330)
 
 ## 7.2.0
 * **feature** Added support for the Swift Package Manager. [#312](https://github.com/matomo-org/matomo-sdk-ios/pull/312)


### PR DESCRIPTION
There was a feature replacing generic string in the user agent with the real device model (#253), which was removed in WKWebView migration (#308). It would be great to have it back if possible :)