### PR TITLE
Manually generated UserAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* **improvement** Completely overhauled the UserAgent generation for automatic device and OS discovery. [#353](https://github.com/matomo-org/matomo-sdk-ios/pull/353)
+
 ## 7.2.2
 * **bugfix** Fixed bug, where new session not started manually [#325](https://github.com/matomo-org/matomo-sdk-ios/issues/325)
 

--- a/Example/ios/ios.xcodeproj/project.pbxproj
+++ b/Example/ios/ios.xcodeproj/project.pbxproj
@@ -107,7 +107,7 @@
 		CD5F3BED18678C9000D04E03 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/CoreLocation.framework; sourceTree = DEVELOPER_DIR; };
 		CD7ABB131B0FD0D2002312DA /* DownloadViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DownloadViewController.h; sourceTree = "<group>"; };
 		CD7ABB141B0FD0D2002312DA /* DownloadViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DownloadViewController.m; sourceTree = "<group>"; };
-		CD93EC8B17E76E290062BE20 /* ios.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ios.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD93EC8B17E76E290062BE20 /* MatomoTrackerExampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MatomoTrackerExampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD93EC9117E76E290062BE20 /* PiwikTrackeriOSDemo-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "PiwikTrackeriOSDemo-Info.plist"; sourceTree = "<group>"; };
 		CD93EC9317E76E290062BE20 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CD93EC9517E76E290062BE20 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -168,7 +168,7 @@
 		CD10FABD17B0378D0012BE50 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				CD93EC8B17E76E290062BE20 /* ios.app */,
+				CD93EC8B17E76E290062BE20 /* MatomoTrackerExampleApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -248,9 +248,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		CD93EC8A17E76E290062BE20 /* ios */ = {
+		CD93EC8A17E76E290062BE20 /* MatomoTrackerExampleApp */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CD93ECAC17E76E290062BE20 /* Build configuration list for PBXNativeTarget "ios" */;
+			buildConfigurationList = CD93ECAC17E76E290062BE20 /* Build configuration list for PBXNativeTarget "MatomoTrackerExampleApp" */;
 			buildPhases = (
 				434B17FA41C3CDFE84FF8205 /* [CP] Check Pods Manifest.lock */,
 				CD93EC8717E76E290062BE20 /* Sources */,
@@ -262,9 +262,9 @@
 			);
 			dependencies = (
 			);
-			name = ios;
+			name = MatomoTrackerExampleApp;
 			productName = PiwikTrackeriOSDemo;
-			productReference = CD93EC8B17E76E290062BE20 /* ios.app */;
+			productReference = CD93EC8B17E76E290062BE20 /* MatomoTrackerExampleApp.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -296,7 +296,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				CD93EC8A17E76E290062BE20 /* ios */,
+				CD93EC8A17E76E290062BE20 /* MatomoTrackerExampleApp */,
 				CDC335FE17B97B110098386C /* Documentation */,
 				CDE4CAE61813DDFE007E0EF7 /* Upload API */,
 			);
@@ -617,7 +617,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CD93ECAC17E76E290062BE20 /* Build configuration list for PBXNativeTarget "ios" */ = {
+		CD93ECAC17E76E290062BE20 /* Build configuration list for PBXNativeTarget "MatomoTrackerExampleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				CD93ECAA17E76E290062BE20 /* Debug */,

--- a/Example/ios/ios.xcodeproj/project.pbxproj
+++ b/Example/ios/ios.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		1FDC91791F1A648C0046F506 /* ObjectiveCCompatibilityChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC91741F1A648C0046F506 /* ObjectiveCCompatibilityChecker.m */; };
 		1FDC917A1F1A648C0046F506 /* OptOutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC91751F1A648C0046F506 /* OptOutViewController.swift */; };
 		1FFE0C272095C0E500DE23B1 /* CampaignViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFE0C262095C0E400DE23B1 /* CampaignViewController.swift */; };
+		22E0E5EC287843B9B1A83B90 /* Pods_example_iOSExampleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41327B74DAF6958954BA8D0A /* Pods_example_iOSExampleApp.framework */; };
 		24F6AE8F1F61FDE200C6C22C /* UserIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F6AE8E1F61FDE200C6C22C /* UserIDViewController.swift */; };
 		CD93EC8C17E76E290062BE20 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD1EA93417B0DA4400F63E14 /* UIKit.framework */; };
 		CD93EC8D17E76E290062BE20 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD10FABF17B0378D0012BE50 /* Foundation.framework */; };
@@ -60,7 +61,6 @@
 		CDC55E2918017D530019A03E /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD1EA93217B0DA3E00F63E14 /* CoreData.framework */; };
 		CDC55E2A18017D630019A03E /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD2F7DAF17B9561C00E240FC /* CoreLocation.framework */; };
 		EB82ABD820DA125100083494 /* ContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB82ABD720DA125100083494 /* ContentViewController.swift */; };
-		F8A9F7D97906DD313D029A2D /* Pods_example_ios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF14E5FDE67AFE4EE7C8B67B /* Pods_example_ios.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -92,7 +92,10 @@
 		1FDC91751F1A648C0046F506 /* OptOutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptOutViewController.swift; sourceTree = "<group>"; };
 		1FFE0C262095C0E400DE23B1 /* CampaignViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CampaignViewController.swift; sourceTree = "<group>"; };
 		24F6AE8E1F61FDE200C6C22C /* UserIDViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserIDViewController.swift; sourceTree = "<group>"; };
+		2670D5A26AB928EDC61E1EB1 /* Pods-example-iOSExampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-iOSExampleApp.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-iOSExampleApp/Pods-example-iOSExampleApp.debug.xcconfig"; sourceTree = "<group>"; };
 		3AEBBD63B45D1F968424585B /* libPods-iosafnetworking2.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iosafnetworking2.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		41327B74DAF6958954BA8D0A /* Pods_example_iOSExampleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_example_iOSExampleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8AEA4A132C5BFFF42F394052 /* Pods-example-iOSExampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-iOSExampleApp.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-iOSExampleApp/Pods-example-iOSExampleApp.release.xcconfig"; sourceTree = "<group>"; };
 		9BB58213275F072D13140292 /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A512D280229592361DDA7E8D /* Pods-example-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-ios.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-ios/Pods-example-ios.release.xcconfig"; sourceTree = "<group>"; };
 		AC92312231977BC13ABD15F1 /* Pods-example-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-ios.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-ios/Pods-example-ios.debug.xcconfig"; sourceTree = "<group>"; };
@@ -126,7 +129,6 @@
 		CDEDC027189518B00054CF73 /* EcommerceViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EcommerceViewController.h; sourceTree = "<group>"; };
 		CDEDC028189518B00054CF73 /* EcommerceViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EcommerceViewController.m; sourceTree = "<group>"; };
 		EB82ABD720DA125100083494 /* ContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewController.swift; sourceTree = "<group>"; };
-		EF14E5FDE67AFE4EE7C8B67B /* Pods_example_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_example_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -139,7 +141,7 @@
 				CDC55E2918017D530019A03E /* CoreData.framework in Frameworks */,
 				CDC55E2A18017D630019A03E /* CoreLocation.framework in Frameworks */,
 				CD93EC8E17E76E290062BE20 /* CoreGraphics.framework in Frameworks */,
-				F8A9F7D97906DD313D029A2D /* Pods_example_ios.framework in Frameworks */,
+				22E0E5EC287843B9B1A83B90 /* Pods_example_iOSExampleApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -151,6 +153,8 @@
 			children = (
 				AC92312231977BC13ABD15F1 /* Pods-example-ios.debug.xcconfig */,
 				A512D280229592361DDA7E8D /* Pods-example-ios.release.xcconfig */,
+				2670D5A26AB928EDC61E1EB1 /* Pods-example-iOSExampleApp.debug.xcconfig */,
+				8AEA4A132C5BFFF42F394052 /* Pods-example-iOSExampleApp.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -186,7 +190,7 @@
 				9BB58213275F072D13140292 /* libPods-ios.a */,
 				3AEBBD63B45D1F968424585B /* libPods-iosafnetworking2.a */,
 				AFEF98FA72F773DD178FA44C /* libPods-osx.a */,
-				EF14E5FDE67AFE4EE7C8B67B /* Pods_example_ios.framework */,
+				41327B74DAF6958954BA8D0A /* Pods_example_iOSExampleApp.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -248,9 +252,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		CD93EC8A17E76E290062BE20 /* MatomoTrackerExampleApp */ = {
+		CD93EC8A17E76E290062BE20 /* iOSExampleApp */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CD93ECAC17E76E290062BE20 /* Build configuration list for PBXNativeTarget "MatomoTrackerExampleApp" */;
+			buildConfigurationList = CD93ECAC17E76E290062BE20 /* Build configuration list for PBXNativeTarget "iOSExampleApp" */;
 			buildPhases = (
 				434B17FA41C3CDFE84FF8205 /* [CP] Check Pods Manifest.lock */,
 				CD93EC8717E76E290062BE20 /* Sources */,
@@ -262,7 +266,7 @@
 			);
 			dependencies = (
 			);
-			name = MatomoTrackerExampleApp;
+			name = iOSExampleApp;
 			productName = PiwikTrackeriOSDemo;
 			productReference = CD93EC8B17E76E290062BE20 /* MatomoTrackerExampleApp.app */;
 			productType = "com.apple.product-type.application";
@@ -296,7 +300,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				CD93EC8A17E76E290062BE20 /* MatomoTrackerExampleApp */,
+				CD93EC8A17E76E290062BE20 /* iOSExampleApp */,
 				CDC335FE17B97B110098386C /* Documentation */,
 				CDE4CAE61813DDFE007E0EF7 /* Upload API */,
 			);
@@ -325,7 +329,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-example-ios/Pods-example-ios-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-example-iOSExampleApp/Pods-example-iOSExampleApp-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MatomoTracker-iOS/MatomoTracker.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -334,7 +338,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-example-ios/Pods-example-ios-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-example-iOSExampleApp/Pods-example-iOSExampleApp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		434B17FA41C3CDFE84FF8205 /* [CP] Check Pods Manifest.lock */ = {
@@ -348,7 +352,7 @@
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-example-ios-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-example-iOSExampleApp-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -535,7 +539,7 @@
 		};
 		CD93ECAA17E76E290062BE20 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AC92312231977BC13ABD15F1 /* Pods-example-ios.debug.xcconfig */;
+			baseConfigurationReference = 2670D5A26AB928EDC61E1EB1 /* Pods-example-iOSExampleApp.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
@@ -557,7 +561,7 @@
 		};
 		CD93ECAB17E76E290062BE20 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A512D280229592361DDA7E8D /* Pods-example-ios.release.xcconfig */;
+			baseConfigurationReference = 8AEA4A132C5BFFF42F394052 /* Pods-example-iOSExampleApp.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
@@ -617,7 +621,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CD93ECAC17E76E290062BE20 /* Build configuration list for PBXNativeTarget "MatomoTrackerExampleApp" */ = {
+		CD93ECAC17E76E290062BE20 /* Build configuration list for PBXNativeTarget "iOSExampleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				CD93ECAA17E76E290062BE20 /* Debug */,

--- a/Example/ios/ios.xcodeproj/xcshareddata/xcschemes/ios.xcscheme
+++ b/Example/ios/ios.xcodeproj/xcshareddata/xcschemes/ios.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CD93EC8A17E76E290062BE20"
-               BuildableName = "ios.app"
-               BlueprintName = "ios"
+               BuildableName = "MatomoTrackerExampleApp.app"
+               BlueprintName = "MatomoTrackerExampleApp"
                ReferencedContainer = "container:ios.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -31,8 +31,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CD93EC8A17E76E290062BE20"
-            BuildableName = "ios.app"
-            BlueprintName = "ios"
+            BuildableName = "MatomoTrackerExampleApp.app"
+            BlueprintName = "MatomoTrackerExampleApp"
             ReferencedContainer = "container:ios.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -54,8 +54,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CD93EC8A17E76E290062BE20"
-            BuildableName = "ios.app"
-            BlueprintName = "ios"
+            BuildableName = "MatomoTrackerExampleApp.app"
+            BlueprintName = "MatomoTrackerExampleApp"
             ReferencedContainer = "container:ios.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -71,8 +71,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CD93EC8A17E76E290062BE20"
-            BuildableName = "ios.app"
-            BlueprintName = "ios"
+            BuildableName = "MatomoTrackerExampleApp.app"
+            BlueprintName = "MatomoTrackerExampleApp"
             ReferencedContainer = "container:ios.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/Example/ios/ios.xcodeproj/xcshareddata/xcschemes/ios.xcscheme
+++ b/Example/ios/ios.xcodeproj/xcshareddata/xcschemes/ios.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CD93EC8A17E76E290062BE20"
-               BuildableName = "MatomoTrackerExampleApp.app"
-               BlueprintName = "MatomoTrackerExampleApp"
+               BuildableName = "iOSExampleApp.app"
+               BlueprintName = "iOSExampleApp"
                ReferencedContainer = "container:ios.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -31,8 +31,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CD93EC8A17E76E290062BE20"
-            BuildableName = "MatomoTrackerExampleApp.app"
-            BlueprintName = "MatomoTrackerExampleApp"
+            BuildableName = "iOSExampleApp.app"
+            BlueprintName = "iOSExampleApp"
             ReferencedContainer = "container:ios.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -54,8 +54,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CD93EC8A17E76E290062BE20"
-            BuildableName = "MatomoTrackerExampleApp.app"
-            BlueprintName = "MatomoTrackerExampleApp"
+            BuildableName = "iOSExampleApp.app"
+            BlueprintName = "iOSExampleApp"
             ReferencedContainer = "container:ios.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -71,8 +71,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CD93EC8A17E76E290062BE20"
-            BuildableName = "MatomoTrackerExampleApp.app"
-            BlueprintName = "MatomoTrackerExampleApp"
+            BuildableName = "iOSExampleApp.app"
+            BlueprintName = "iOSExampleApp"
             ReferencedContainer = "container:ios.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/Example/macos/macos.xcodeproj/project.pbxproj
+++ b/Example/macos/macos.xcodeproj/project.pbxproj
@@ -12,20 +12,22 @@
 		1F88019A1EBFBBCC00707352 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1F8801991EBFBBCC00707352 /* Assets.xcassets */; };
 		1F88019D1EBFBBCC00707352 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1F88019B1EBFBBCC00707352 /* Main.storyboard */; };
 		1FC2A0E92195C6340039EE0C /* MatomoTracker+SharedInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC2A0E82195C6340039EE0C /* MatomoTracker+SharedInstance.swift */; };
-		E9C171B28E33B897204F7A14 /* Pods_example_macos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A25A82DCA8469434D57EE94 /* Pods_example_macos.framework */; };
+		78E0609CE0960B7A7E1301D5 /* Pods_example_macOSExampleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE82671710912443DF0BEADD /* Pods_example_macOSExampleApp.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		1F8801921EBFBBCC00707352 /* macos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = macos.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F8801921EBFBBCC00707352 /* macOSExampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = macOSExampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F8801951EBFBBCC00707352 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1F8801971EBFBBCC00707352 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		1F8801991EBFBBCC00707352 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1F88019C1EBFBBCC00707352 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		1F88019E1EBFBBCC00707352 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1FC2A0E82195C6340039EE0C /* MatomoTracker+SharedInstance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MatomoTracker+SharedInstance.swift"; sourceTree = "<group>"; };
+		2F91CCB498FE7772A1C27ECA /* Pods-example-macOSExampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-macOSExampleApp.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-macOSExampleApp/Pods-example-macOSExampleApp.release.xcconfig"; sourceTree = "<group>"; };
+		5592C0CAE8AE9F4CC7BECB76 /* Pods-example-macOSExampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-macOSExampleApp.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-macOSExampleApp/Pods-example-macOSExampleApp.debug.xcconfig"; sourceTree = "<group>"; };
 		6E5F466A5CEB9E4EE4BB5F02 /* Pods-example-macos.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-macos.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-macos/Pods-example-macos.debug.xcconfig"; sourceTree = "<group>"; };
 		7ABE41F256CAD8BC6F7A7450 /* Pods-example-macos.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-macos.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-macos/Pods-example-macos.release.xcconfig"; sourceTree = "<group>"; };
-		9A25A82DCA8469434D57EE94 /* Pods_example_macos.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_example_macos.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE82671710912443DF0BEADD /* Pods_example_macOSExampleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_example_macOSExampleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -33,7 +35,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E9C171B28E33B897204F7A14 /* Pods_example_macos.framework in Frameworks */,
+				78E0609CE0960B7A7E1301D5 /* Pods_example_macOSExampleApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -43,7 +45,7 @@
 		1B48FAA6A48C6872B98BA8ED /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				9A25A82DCA8469434D57EE94 /* Pods_example_macos.framework */,
+				DE82671710912443DF0BEADD /* Pods_example_macOSExampleApp.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -61,7 +63,7 @@
 		1F8801931EBFBBCC00707352 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				1F8801921EBFBBCC00707352 /* macos.app */,
+				1F8801921EBFBBCC00707352 /* macOSExampleApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -84,6 +86,8 @@
 			children = (
 				6E5F466A5CEB9E4EE4BB5F02 /* Pods-example-macos.debug.xcconfig */,
 				7ABE41F256CAD8BC6F7A7450 /* Pods-example-macos.release.xcconfig */,
+				5592C0CAE8AE9F4CC7BECB76 /* Pods-example-macOSExampleApp.debug.xcconfig */,
+				2F91CCB498FE7772A1C27ECA /* Pods-example-macOSExampleApp.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -91,9 +95,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		1F8801911EBFBBCC00707352 /* macos */ = {
+		1F8801911EBFBBCC00707352 /* macOSExampleApp */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1F8801A11EBFBBCC00707352 /* Build configuration list for PBXNativeTarget "macos" */;
+			buildConfigurationList = 1F8801A11EBFBBCC00707352 /* Build configuration list for PBXNativeTarget "macOSExampleApp" */;
 			buildPhases = (
 				0A40666338FA518C793771B7 /* [CP] Check Pods Manifest.lock */,
 				1F88018E1EBFBBCC00707352 /* Sources */,
@@ -105,9 +109,9 @@
 			);
 			dependencies = (
 			);
-			name = macos;
+			name = macOSExampleApp;
 			productName = macos;
-			productReference = 1F8801921EBFBBCC00707352 /* macos.app */;
+			productReference = 1F8801921EBFBBCC00707352 /* macOSExampleApp.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -141,7 +145,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				1F8801911EBFBBCC00707352 /* macos */,
+				1F8801911EBFBBCC00707352 /* macOSExampleApp */,
 			);
 		};
 /* End PBXProject section */
@@ -170,7 +174,7 @@
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-example-macos-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-example-macOSExampleApp-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -183,7 +187,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-example-macos/Pods-example-macos-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-example-macOSExampleApp/Pods-example-macOSExampleApp-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MatomoTracker-macOS/MatomoTracker.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -192,7 +196,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-example-macos/Pods-example-macos-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-example-macOSExampleApp/Pods-example-macOSExampleApp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -334,7 +338,7 @@
 		};
 		1F8801A21EBFBBCC00707352 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E5F466A5CEB9E4EE4BB5F02 /* Pods-example-macos.debug.xcconfig */;
+			baseConfigurationReference = 5592C0CAE8AE9F4CC7BECB76 /* Pods-example-macOSExampleApp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -349,7 +353,7 @@
 		};
 		1F8801A31EBFBBCC00707352 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7ABE41F256CAD8BC6F7A7450 /* Pods-example-macos.release.xcconfig */;
+			baseConfigurationReference = 2F91CCB498FE7772A1C27ECA /* Pods-example-macOSExampleApp.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -374,7 +378,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1F8801A11EBFBBCC00707352 /* Build configuration list for PBXNativeTarget "macos" */ = {
+		1F8801A11EBFBBCC00707352 /* Build configuration list for PBXNativeTarget "macOSExampleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1F8801A21EBFBBCC00707352 /* Debug */,

--- a/Example/macos/macos.xcodeproj/xcshareddata/xcschemes/macos.xcscheme
+++ b/Example/macos/macos.xcodeproj/xcshareddata/xcschemes/macos.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "1F8801911EBFBBCC00707352"
-               BuildableName = "macos.app"
-               BlueprintName = "macos"
+               BuildableName = "macOSExampleApp.app"
+               BlueprintName = "macOSExampleApp"
                ReferencedContainer = "container:macos.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -27,19 +27,17 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1F8801911EBFBBCC00707352"
-            BuildableName = "macos.app"
-            BlueprintName = "macos"
+            BuildableName = "macOSExampleApp.app"
+            BlueprintName = "macOSExampleApp"
             ReferencedContainer = "container:macos.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -56,13 +54,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1F8801911EBFBBCC00707352"
-            BuildableName = "macos.app"
-            BlueprintName = "macos"
+            BuildableName = "macOSExampleApp.app"
+            BlueprintName = "macOSExampleApp"
             ReferencedContainer = "container:macos.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -75,8 +71,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1F8801911EBFBBCC00707352"
-            BuildableName = "macos.app"
-            BlueprintName = "macos"
+            BuildableName = "macOSExampleApp.app"
+            BlueprintName = "macOSExampleApp"
             ReferencedContainer = "container:macos.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/Example/tvos/tvos.xcodeproj/project.pbxproj
+++ b/Example/tvos/tvos.xcodeproj/project.pbxproj
@@ -12,12 +12,11 @@
 		1F38EBEE1EE55AE50021FBF8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1F38EBEC1EE55AE50021FBF8 /* Main.storyboard */; };
 		1F38EBF01EE55AE50021FBF8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1F38EBEF1EE55AE50021FBF8 /* Assets.xcassets */; };
 		1FC2A0EB2195C98B0039EE0C /* MatomoTracker+SharedInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC2A0EA2195C98B0039EE0C /* MatomoTracker+SharedInstance.swift */; };
-		607D4B3ABA064DC5DA050144 /* Pods_example_tvos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0907CCC9B4E1BA377380424F /* Pods_example_tvos.framework */; };
+		4335EDAD05012B4AB2074069 /* Pods_example_tvOSExampleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9B6234104CCCE5C6F7FEAF6 /* Pods_example_tvOSExampleApp.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0907CCC9B4E1BA377380424F /* Pods_example_tvos.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_example_tvos.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1F38EBE51EE55AE50021FBF8 /* tvos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tvos.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F38EBE51EE55AE50021FBF8 /* tvOSExampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tvOSExampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F38EBE81EE55AE50021FBF8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1F38EBEA1EE55AE50021FBF8 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		1F38EBED1EE55AE50021FBF8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -25,7 +24,10 @@
 		1F38EBF11EE55AE50021FBF8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1FC2A0EA2195C98B0039EE0C /* MatomoTracker+SharedInstance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MatomoTracker+SharedInstance.swift"; sourceTree = "<group>"; };
 		2CE39FB3D2EC21407896280A /* Pods-example-tvos.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-tvos.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-tvos/Pods-example-tvos.release.xcconfig"; sourceTree = "<group>"; };
+		3FCC224653B51A1346A4CA0F /* Pods-example-tvOSExampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-tvOSExampleApp.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-tvOSExampleApp/Pods-example-tvOSExampleApp.debug.xcconfig"; sourceTree = "<group>"; };
+		47BE969E3E739CD830ACE064 /* Pods-example-tvOSExampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-tvOSExampleApp.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-tvOSExampleApp/Pods-example-tvOSExampleApp.release.xcconfig"; sourceTree = "<group>"; };
 		918636219B28741F62F0C1D0 /* Pods-example-tvos.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-tvos.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-example-tvos/Pods-example-tvos.debug.xcconfig"; sourceTree = "<group>"; };
+		F9B6234104CCCE5C6F7FEAF6 /* Pods_example_tvOSExampleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_example_tvOSExampleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -33,7 +35,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				607D4B3ABA064DC5DA050144 /* Pods_example_tvos.framework in Frameworks */,
+				4335EDAD05012B4AB2074069 /* Pods_example_tvOSExampleApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -45,6 +47,8 @@
 			children = (
 				918636219B28741F62F0C1D0 /* Pods-example-tvos.debug.xcconfig */,
 				2CE39FB3D2EC21407896280A /* Pods-example-tvos.release.xcconfig */,
+				3FCC224653B51A1346A4CA0F /* Pods-example-tvOSExampleApp.debug.xcconfig */,
+				47BE969E3E739CD830ACE064 /* Pods-example-tvOSExampleApp.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -62,7 +66,7 @@
 		1F38EBE61EE55AE50021FBF8 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				1F38EBE51EE55AE50021FBF8 /* tvos.app */,
+				1F38EBE51EE55AE50021FBF8 /* tvOSExampleApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -83,7 +87,7 @@
 		D3EFD56183CA883BC9A8C5F9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				0907CCC9B4E1BA377380424F /* Pods_example_tvos.framework */,
+				F9B6234104CCCE5C6F7FEAF6 /* Pods_example_tvOSExampleApp.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -91,9 +95,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		1F38EBE41EE55AE50021FBF8 /* tvos */ = {
+		1F38EBE41EE55AE50021FBF8 /* tvOSExampleApp */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1F38EBF41EE55AE50021FBF8 /* Build configuration list for PBXNativeTarget "tvos" */;
+			buildConfigurationList = 1F38EBF41EE55AE50021FBF8 /* Build configuration list for PBXNativeTarget "tvOSExampleApp" */;
 			buildPhases = (
 				A7D0D37AD3004C01CA94CC9D /* [CP] Check Pods Manifest.lock */,
 				1F38EBE11EE55AE50021FBF8 /* Sources */,
@@ -105,9 +109,9 @@
 			);
 			dependencies = (
 			);
-			name = tvos;
+			name = tvOSExampleApp;
 			productName = tvos;
-			productReference = 1F38EBE51EE55AE50021FBF8 /* tvos.app */;
+			productReference = 1F38EBE51EE55AE50021FBF8 /* tvOSExampleApp.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -140,7 +144,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				1F38EBE41EE55AE50021FBF8 /* tvos */,
+				1F38EBE41EE55AE50021FBF8 /* tvOSExampleApp */,
 			);
 		};
 /* End PBXProject section */
@@ -164,7 +168,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-example-tvos/Pods-example-tvos-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-example-tvOSExampleApp/Pods-example-tvOSExampleApp-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MatomoTracker-tvOS/MatomoTracker.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -173,7 +177,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-example-tvos/Pods-example-tvos-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-example-tvOSExampleApp/Pods-example-tvOSExampleApp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A7D0D37AD3004C01CA94CC9D /* [CP] Check Pods Manifest.lock */ = {
@@ -187,7 +191,7 @@
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-example-tvos-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-example-tvOSExampleApp-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -334,7 +338,7 @@
 		};
 		1F38EBF51EE55AE50021FBF8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 918636219B28741F62F0C1D0 /* Pods-example-tvos.debug.xcconfig */;
+			baseConfigurationReference = 3FCC224653B51A1346A4CA0F /* Pods-example-tvOSExampleApp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -348,7 +352,7 @@
 		};
 		1F38EBF61EE55AE50021FBF8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2CE39FB3D2EC21407896280A /* Pods-example-tvos.release.xcconfig */;
+			baseConfigurationReference = 47BE969E3E739CD830ACE064 /* Pods-example-tvOSExampleApp.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -372,7 +376,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1F38EBF41EE55AE50021FBF8 /* Build configuration list for PBXNativeTarget "tvos" */ = {
+		1F38EBF41EE55AE50021FBF8 /* Build configuration list for PBXNativeTarget "tvOSExampleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1F38EBF51EE55AE50021FBF8 /* Debug */,

--- a/Example/tvos/tvos.xcodeproj/xcshareddata/xcschemes/tvos.xcscheme
+++ b/Example/tvos/tvos.xcodeproj/xcshareddata/xcschemes/tvos.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "1F38EBE41EE55AE50021FBF8"
-               BuildableName = "tvos.app"
-               BlueprintName = "tvos"
+               BuildableName = "tvOSExampleApp.app"
+               BlueprintName = "tvOSExampleApp"
                ReferencedContainer = "container:tvos.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -27,19 +27,17 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1F38EBE41EE55AE50021FBF8"
-            BuildableName = "tvos.app"
-            BlueprintName = "tvos"
+            BuildableName = "tvOSExampleApp.app"
+            BlueprintName = "tvOSExampleApp"
             ReferencedContainer = "container:tvos.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -56,13 +54,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1F38EBE41EE55AE50021FBF8"
-            BuildableName = "tvos.app"
-            BlueprintName = "tvos"
+            BuildableName = "tvOSExampleApp.app"
+            BlueprintName = "tvOSExampleApp"
             ReferencedContainer = "container:tvos.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -75,8 +71,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1F38EBE41EE55AE50021FBF8"
-            BuildableName = "tvos.app"
-            BlueprintName = "tvos"
+            BuildableName = "tvOSExampleApp.app"
+            BlueprintName = "tvOSExampleApp"
             ReferencedContainer = "container:tvos.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/MatomoTracker.podspec
+++ b/MatomoTracker.podspec
@@ -13,9 +13,8 @@ Pod::Spec.new do |spec|
   spec.default_subspecs = 'Core'
   spec.swift_version = '5.0'
   
-  spec.ios.frameworks = 'UIKit', 'WebKit'
+  spec.ios.frameworks = 'UIKit'
   spec.tvos.frameworks = 'UIKit'
-  spec.macos.frameworks = 'WebKit'
   
   spec.subspec 'Core' do |core|
   	core.source_files = 'MatomoTracker/*.swift'

--- a/MatomoTracker.xcodeproj/project.pbxproj
+++ b/MatomoTracker.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		1F3CA58C1E09A30600121FDC /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3CA58B1E09A30600121FDC /* Queue.swift */; };
 		1F5927552178716E001478DC /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 1F5927542178716E001478DC /* CHANGELOG.md */; };
 		1F5D08721F5D79AD0064314F /* AutoTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5D08711F5D79AD0064314F /* AutoTracker.swift */; };
+		1F6B2F032529CE8A00D2A591 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6B2F012529CC3400D2A591 /* UserAgent.swift */; };
 		1F6F0CD71E61E35A008170FC /* MatomoTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6F0CD61E61E35A008170FC /* MatomoTracker.swift */; };
 		1F6F0CDC1E61E377008170FC /* DispatcherStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6F0CD81E61E377008170FC /* DispatcherStub.swift */; };
 		1F6F0CDD1E61E377008170FC /* QueueStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6F0CD91E61E377008170FC /* QueueStub.swift */; };
@@ -64,6 +65,7 @@
 		1F3CA58B1E09A30600121FDC /* Queue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		1F5927542178716E001478DC /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		1F5D08711F5D79AD0064314F /* AutoTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoTracker.swift; sourceTree = "<group>"; };
+		1F6B2F012529CC3400D2A591 /* UserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
 		1F6F0CD61E61E35A008170FC /* MatomoTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatomoTracker.swift; sourceTree = "<group>"; };
 		1F6F0CD81E61E377008170FC /* DispatcherStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatcherStub.swift; sourceTree = "<group>"; };
 		1F6F0CD91E61E377008170FC /* QueueStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueueStub.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 				1FDC917E1F1A65150046F506 /* Device.swift */,
 				1F7C667E1F8C096F0066CC64 /* MainThread.swift */,
 				1F7001CA216C9D8C007A9355 /* EventAPISerializer.swift */,
+				1F6B2F012529CC3400D2A591 /* UserAgent.swift */,
 				1FCA6D3F1DBE0B2F0033F01C /* Info.plist */,
 				1FCA6D3E1DBE0B2F0033F01C /* MatomoTracker.h */,
 			);
@@ -394,6 +397,7 @@
 				1F092C161E225E0200394B30 /* Event.swift in Sources */,
 				1F092C141E224C3E00394B30 /* MatomoUserDefaults.swift in Sources */,
 				1F6F0CD71E61E35A008170FC /* MatomoTracker.swift in Sources */,
+				1F6B2F032529CE8A00D2A591 /* UserAgent.swift in Sources */,
 				1F1949F21E17A91100458199 /* MemoryQueue.swift in Sources */,
 				1FDC91801F1A65150046F506 /* Device.swift in Sources */,
 				1F7001CB216C9D8C007A9355 /* EventAPISerializer.swift in Sources */,

--- a/MatomoTracker/Application.swift
+++ b/MatomoTracker/Application.swift
@@ -10,7 +10,8 @@ public struct Application {
         let identifier = bundleIdentifierForCurrentApplication()
         let version = bundleVersionForCurrentApplication()
         let shortVersion = bundleShortVersionForCurrentApplication()
-        return Application(bundleDisplayName: displayName, bundleName: name, bundleIdentifier: identifier, bundleVersion: version, bundleShortVersion: shortVersion)
+        let matomoSDKVersion = matomoSDKVersionForCurrentApplication()
+        return Application(bundleDisplayName: displayName, bundleName: name, bundleIdentifier: identifier, bundleVersion: version, bundleShortVersion: shortVersion, matomoSDKVersion: matomoSDKVersion)
     }
     
     /// The name of your app as displayed on the homescreen i.e. "My App"
@@ -27,6 +28,9 @@ public struct Application {
     
     /// The app version as String i.e. "1.0.1"
     public let bundleShortVersion: String?
+    
+    /// The version of the matomo sdk i.e. "7.2"
+    public let matomoSDKVersion: String?
 }
 
 extension Application {
@@ -53,5 +57,9 @@ extension Application {
     /// Returns the app version
     private static func bundleShortVersionForCurrentApplication() -> String? {
         return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+    
+    private static func matomoSDKVersionForCurrentApplication() -> String? {
+        return Bundle(for: MatomoTracker.self).infoDictionary?["CFBundleShortVersionString"] as? String
     }
 }

--- a/MatomoTracker/Application.swift
+++ b/MatomoTracker/Application.swift
@@ -10,8 +10,7 @@ public struct Application {
         let identifier = bundleIdentifierForCurrentApplication()
         let version = bundleVersionForCurrentApplication()
         let shortVersion = bundleShortVersionForCurrentApplication()
-        let matomoSDKVersion = matomoSDKVersionForCurrentApplication()
-        return Application(bundleDisplayName: displayName, bundleName: name, bundleIdentifier: identifier, bundleVersion: version, bundleShortVersion: shortVersion, matomoSDKVersion: matomoSDKVersion)
+        return Application(bundleDisplayName: displayName, bundleName: name, bundleIdentifier: identifier, bundleVersion: version, bundleShortVersion: shortVersion)
     }
     
     /// The name of your app as displayed on the homescreen i.e. "My App"
@@ -28,9 +27,6 @@ public struct Application {
     
     /// The app version as String i.e. "1.0.1"
     public let bundleShortVersion: String?
-    
-    /// The version of the matomo sdk i.e. "7.2"
-    public let matomoSDKVersion: String?
 }
 
 extension Application {
@@ -57,9 +53,5 @@ extension Application {
     /// Returns the app version
     private static func bundleShortVersionForCurrentApplication() -> String? {
         return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-    }
-    
-    private static func matomoSDKVersionForCurrentApplication() -> String? {
-        return Bundle(for: MatomoTracker.self).infoDictionary?["CFBundleShortVersionString"] as? String
     }
 }

--- a/MatomoTracker/Device.swift
+++ b/MatomoTracker/Device.swift
@@ -5,12 +5,14 @@ final public class Device: NSObject {
     @objc public static func makeCurrentDevice() ->  Device {
         let platform = currentPlatform()
         let humanReadablePlatformName = humanReadablePlatformNameForCurrentDevice()
+        let operatingSystem = operatingSystemForCurrentDevice()
         let os = osVersionForCurrentDevice()
         let screenSize = screenSizeForCurrentDevice()
         let nativeScreenSize = nativeScreenSizeForCurrentDevice()
         let darwinVersion = darwinVersionForCurrentDevice()
         return Device(platform: platform,
                       humanReadablePlatformName: humanReadablePlatformName,
+                      operatingSystem: operatingSystem,
                       osVersion: os,
                       screenSize: screenSize,
                       nativeScreenSize: nativeScreenSize,
@@ -19,6 +21,8 @@ final public class Device: NSObject {
     
     /// The platform name of the device i.e. "iPhone1,1" or "iPad3,6"
     @objc public let platform: String
+    
+    @objc public let operatingSystem: String
     
     /// A human readable version of the platform name i.e. "iPhone 6 Plus" or "iPad Air 2 (WiFi)"
     /// Will be nil if no human readable string was found.
@@ -37,9 +41,10 @@ final public class Device: NSObject {
     /// The darwin version as fetched from utsname()
     @objc public let darwinVersion: String?
 
-    required public init(platform: String, humanReadablePlatformName: String? = nil, osVersion: String, screenSize: CGSize, nativeScreenSize: CGSize? = nil, darwinVersion: String? = nil) {
+    required public init(platform: String, humanReadablePlatformName: String? = nil, operatingSystem: String, osVersion: String, screenSize: CGSize, nativeScreenSize: CGSize? = nil, darwinVersion: String? = nil) {
         self.platform = platform
         self.humanReadablePlatformName = humanReadablePlatformName
+        self.operatingSystem = operatingSystem
         self.osVersion = osVersion
         self.screenSize = screenSize
         self.nativeScreenSize = nativeScreenSize != nil ? nativeScreenSize! : CGSize.zero
@@ -207,6 +212,10 @@ extension Device {
 #if os(OSX)
     import AppKit
     extension Device {
+        internal static func operatingSystemForCurrentDevice() -> String {
+            return "macOS"
+        }
+        
         /// Returns the version number of the current OS as String i.e. "1.2" or "9.4"
         internal static func osVersionForCurrentDevice() -> String  {
             let version = ProcessInfo.processInfo.operatingSystemVersion
@@ -227,6 +236,13 @@ extension Device {
 #elseif os(iOS) || os(tvOS)
     import UIKit
     extension Device {
+        internal static func operatingSystemForCurrentDevice() -> String {
+            #if os(iOS)
+            return "iOS"
+            #elseif os(tvOS)
+            return "tvOS"
+            #endif
+        }
         
         /// Returns the version number of the current OS as String i.e. "1.2" or "9.4"
         internal static func osVersionForCurrentDevice() -> String  {

--- a/MatomoTracker/MatomoTracker.swift
+++ b/MatomoTracker/MatomoTracker.swift
@@ -463,3 +463,8 @@ extension MatomoTracker {
         matomoUserDefaults.copy(from: UserDefaults.standard)
     }
 }
+
+extension MatomoTracker {
+    /// The version of the Matomo SDKs
+    @objc public static let sdkVersion = "7.2.2"
+}

--- a/MatomoTracker/UserAgent.swift
+++ b/MatomoTracker/UserAgent.swift
@@ -13,6 +13,6 @@ struct UserAgent {
     let device: Device
     
     var stringValue: String {
-        "\(application.bundleDisplayName ?? "Unknown-App")/\(application.bundleShortVersion ?? "Unknown-Version") \(device.platform) \(device.operatingSystem)/\(device.osVersion) MatomoTrackerIOSSDK/\(application.matomoSDKVersion ?? "Unknown-Version") Darwin/\(device.darwinVersion ?? "Unknown-Version")"
+        "\(application.bundleName ?? "Unknown-App")/\(application.bundleShortVersion ?? "Unknown-Version") \(device.platform) \(device.operatingSystem)/\(device.osVersion) MatomoTrackerIOSSDK/\(application.matomoSDKVersion ?? "Unknown-Version") Darwin/\(device.darwinVersion ?? "Unknown-Version")"
     }
 }

--- a/MatomoTracker/UserAgent.swift
+++ b/MatomoTracker/UserAgent.swift
@@ -13,6 +13,6 @@ struct UserAgent {
     let device: Device
     
     var stringValue: String {
-        "\(application.bundleName ?? "Unknown-App")/\(application.bundleShortVersion ?? "Unknown-Version") \(device.platform) \(device.operatingSystem)/\(device.osVersion) MatomoTrackerIOSSDK/\(application.matomoSDKVersion ?? "Unknown-Version") Darwin/\(device.darwinVersion ?? "Unknown-Version")"
+        "\(application.bundleName ?? "Unknown-App")/\(application.bundleShortVersion ?? "Unknown-Version") \(device.platform) \(device.operatingSystem)/\(device.osVersion) MatomoTrackerSDK/\(application.matomoSDKVersion ?? "Unknown-Version") Darwin/\(device.darwinVersion ?? "Unknown-Version")"
     }
 }

--- a/MatomoTracker/UserAgent.swift
+++ b/MatomoTracker/UserAgent.swift
@@ -13,6 +13,6 @@ struct UserAgent {
     let device: Device
     
     var stringValue: String {
-        "\(application.bundleDisplayName ?? "Unknown-App")/\(application.bundleShortVersion ?? "Unknown-Version") \(device.platform) iOS/\(device.osVersion) MatomoTrackerIOSSDK/\(application.matomoSDKVersion ?? "Unknown-Version") Darwin/\(device.darwinVersion ?? "Unknown-Version")"
+        "\(application.bundleDisplayName ?? "Unknown-App")/\(application.bundleShortVersion ?? "Unknown-Version") \(device.platform) \(device.operatingSystem)/\(device.osVersion) MatomoTrackerIOSSDK/\(application.matomoSDKVersion ?? "Unknown-Version") Darwin/\(device.darwinVersion ?? "Unknown-Version")"
     }
 }

--- a/MatomoTracker/UserAgent.swift
+++ b/MatomoTracker/UserAgent.swift
@@ -13,6 +13,6 @@ struct UserAgent {
     let device: Device
     
     var stringValue: String {
-        "\(application.bundleName ?? "Unknown-App")/\(application.bundleShortVersion ?? "Unknown-Version") \(device.platform) \(device.operatingSystem)/\(device.osVersion) MatomoTrackerSDK/\(application.matomoSDKVersion ?? "Unknown-Version") Darwin/\(device.darwinVersion ?? "Unknown-Version")"
+        "\(application.bundleName ?? "Unknown-App")/\(application.bundleShortVersion ?? "Unknown-Version") \(device.platform) \(device.operatingSystem)/\(device.osVersion) MatomoTrackerSDK/\(MatomoTracker.sdkVersion ?? "Unknown-Version") Darwin/\(device.darwinVersion ?? "Unknown-Version")"
     }
 }

--- a/MatomoTracker/UserAgent.swift
+++ b/MatomoTracker/UserAgent.swift
@@ -1,0 +1,18 @@
+//
+//  UserAgent.swift
+//  MatomoTracker
+//
+//  Created by Cornelius Horstmann on 04.10.20.
+//  Copyright © 2020 Matomo. All rights reserved.
+//
+
+import Foundation
+
+struct UserAgent {
+    let application: Application
+    let device: Device
+    
+    var stringValue: String {
+        "\(application.bundleDisplayName ?? "Unknown-App")/\(application.bundleShortVersion ?? "Unknown-Version") \(device.platform) iOS/\(device.osVersion) MatomoTrackerIOSSDK/\(application.matomoSDKVersion ?? "Unknown-Version") Darwin/\(device.darwinVersion ?? "Unknown-Version")"
+    }
+}

--- a/Podfile
+++ b/Podfile
@@ -6,19 +6,19 @@ abstract_target :example do
   project 'MatomoTracker'
   workspace 'MatomoTracker'
 
-  target :ios do
+  target :iOSExampleApp do
     platform :ios, '10.0'
     project 'Example/ios/ios'
     pod 'MatomoTracker', path: './'
   end
 
-  target :macos do
+  target :macOSExampleApp do
     platform :osx, '10.13'
     project 'Example/macos/macos'
     pod 'MatomoTracker', path: './'
   end
 
-  target :tvos do
+  target :tvOSExampleApp do
     platform :tvos, '10.2'
     project 'Example/tvos/tvos'
     pod 'MatomoTracker', path: './'


### PR DESCRIPTION
I think we need to rethink our UserAgent generation. Right now the SDK asks the WebView to generate the UserAgent and will then replace `iPhone` with the actual iPhone version. There are just to many issues with it:

* WebKit as a dependency
* Asynchronous code: There is no synchronous way to let a WKWebView generate the UserAgent
* When the format of the UserAgent returned by WkWebView changes our code might break (I guess that's what is happening here)

This PR changes this and completely manually generates the UserAgent. The new, generated format is `iOSExampleApp/1.0 iPhone10,4 iOS/13.3 MatomoTrackerIOSSDK/7.2.2 Darwin/18.7.0`.

* `iOSExampleApp/1.0` display name and marketing version of the app
* `iPhone10,4` device identifier
* `iOS/13.3` iOS Version
* `MatomoTrackerIOSSDK/7.2.2` Matomo SKD version
* `Darwin/18.7.0` Darwin version

According to the test website by @Findus23, Matomo parses this format perfectly well: [have a look](https://devicedetector.lw1.at/iOSExampleApp%2F1.0%20iPhone10,4%20iOS%2F13.3%20MatomoTrackerIOSSDK%2F7.2.2%20Darwin%2F18.7.0)