### PR TITLE
Fix copy from UserDefaults method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * **improvement** Fixed build warnings
+* **bugfix** Fixed issue where only `UserDefaults.standard` is used despite specified another instance. [#384](https://github.com/matomo-org/matomo-sdk-ios/pull/384)
 
 ## 7.4.0
 * **improvement** Escaped more symbols when sending events to the API. [#313](https://github.com/matomo-org/matomo-sdk-ios/issues/313)

--- a/MatomoTracker/MatomoUserDefaults.swift
+++ b/MatomoTracker/MatomoUserDefaults.swift
@@ -103,15 +103,15 @@ internal struct MatomoUserDefaults {
 
 extension MatomoUserDefaults {
     public mutating func copy(from userDefaults: UserDefaults) {
-        totalNumberOfVisits = UserDefaults.standard.integer(forKey: MatomoUserDefaults.Key.totalNumberOfVisits)
-        firstVisit = UserDefaults.standard.object(forKey: MatomoUserDefaults.Key.firstVistsTimestamp) as? Date
-        previousVisit = UserDefaults.standard.object(forKey: MatomoUserDefaults.Key.previousVistsTimestamp) as? Date
-        currentVisit = UserDefaults.standard.object(forKey: MatomoUserDefaults.Key.currentVisitTimestamp) as? Date
-        optOut = UserDefaults.standard.bool(forKey: MatomoUserDefaults.Key.optOut)
-        clientId = UserDefaults.standard.string(forKey: MatomoUserDefaults.Key.clientID)
-        forcedVisitorId = UserDefaults.standard.string(forKey: MatomoUserDefaults.Key.forcedVisitorID)
-        visitorUserId = UserDefaults.standard.string(forKey: MatomoUserDefaults.Key.visitorUserID)
-        lastOrder = UserDefaults.standard.object(forKey: MatomoUserDefaults.Key.lastOrder) as? Date
+        totalNumberOfVisits = userDefaults.integer(forKey: MatomoUserDefaults.Key.totalNumberOfVisits)
+        firstVisit = userDefaults.object(forKey: MatomoUserDefaults.Key.firstVistsTimestamp) as? Date
+        previousVisit = userDefaults.object(forKey: MatomoUserDefaults.Key.previousVistsTimestamp) as? Date
+        currentVisit = userDefaults.object(forKey: MatomoUserDefaults.Key.currentVisitTimestamp) as? Date
+        optOut = userDefaults.bool(forKey: MatomoUserDefaults.Key.optOut)
+        clientId = userDefaults.string(forKey: MatomoUserDefaults.Key.clientID)
+        forcedVisitorId = userDefaults.string(forKey: MatomoUserDefaults.Key.forcedVisitorID)
+        visitorUserId = userDefaults.string(forKey: MatomoUserDefaults.Key.visitorUserID)
+        lastOrder = userDefaults.object(forKey: MatomoUserDefaults.Key.lastOrder) as? Date
     }
 }
 


### PR DESCRIPTION
The `MatomoUserDefaults.copy(from:)` method had an unused parameter and was assumed that it will always be `UserDefaults.standard`