### PR TITLE
Remove Legacy Build System

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * **improvement** Fixed build warnings
+* **improvement** Use the new XCode build system
 * **bugfix** Fixed issue where only `UserDefaults.standard` is used despite specified another instance. [#384](https://github.com/matomo-org/matomo-sdk-ios/pull/384)
 
 ## 7.4.0

--- a/MatomoTracker.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/MatomoTracker.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
 </dict>
 </plist>


### PR DESCRIPTION
Remove the legacy build system for the xcworkspace
so the sdk builds (via carthage) using xcode 13.

Closes https://github.com/matomo-org/matomo-sdk-ios/issues/390