### PR TITLE
Update # FAQ Links

### DIFF
--- a/MatomoTracker/Event.swift
+++ b/MatomoTracker/Event.swift
@@ -87,7 +87,7 @@ public struct Event: Codable {
     let revenue: Float?
 
     /// Ecommerce Order tracking
-    /// https://matomo.org/docs/ecommerce-analytics/#tracking-ecommerce-orders-items-purchased-required
+    /// https://matomo.org/faq/reports/advanced-manually-tracking-ecommerce-actions-in-matomo/#tracking-orders-to-matomo-required
     let orderId: String?
     let orderItems: [OrderItem]
     let orderRevenue: Float?

--- a/MatomoTracker/MatomoTracker.swift
+++ b/MatomoTracker/MatomoTracker.swift
@@ -323,7 +323,7 @@ extension MatomoTracker {
         queue(event: event)
     }
 
-    /// Tracks an order as described here: https://matomo.org/docs/ecommerce-analytics/#tracking-ecommerce-orders-items-purchased-required
+    /// Tracks an order as described here: https://matomo.org/faq/reports/advanced-manually-tracking-ecommerce-actions-in-matomo/#tracking-orders-to-matomo-required
     ///
     /// - Parameters:
     ///   - id: The unique ID of the order

--- a/MatomoTracker/OrderItem.swift
+++ b/MatomoTracker/OrderItem.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Order item as described in: https://matomo.org/docs/ecommerce-analytics/#tracking-ecommerce-orders-items-purchased-required
+/// Order item as described in: https://matomo.org/faq/reports/advanced-manually-tracking-ecommerce-actions-in-matomo/#tracking-orders-to-matomo-required
 public struct OrderItem: Codable {
     
     /// The SKU of the order item

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ let matomoTracker = MatomoTracker(siteId: "23", baseURL: URL(string: "https://de
 ```
 
 
-The `siteId` is the ID that you can get if you [add a website](https://matomo.org/docs/manage-websites/#add-a-website) within the Matomo web interface. The `baseURL` it the URL to your Matomo web instance and has to include the "piwik.php" or "matomo.php" string.
+The `siteId` is the ID that you can get if you [add a website](https://matomo.org/faq/how-to/create-and-manage-websites/) within the Matomo web interface. The `baseURL` it the URL to your Matomo web instance and has to include the "piwik.php" or "matomo.php" string.
 
 You can either pass around this instance, or add an extension to the `MatomoTracker` class and add a shared instance property.
 
@@ -56,7 +56,7 @@ extension MatomoTracker {
 }
 ```
 
-The `siteId` is the ID that you can get if you [add a website](https://matomo.org/docs/manage-websites/#add-a-website) within the Matomo web interface. The `baseURL` is the URL to your Matomo web instance and has to include the "piwik.php" or "matomo.php" string.
+The `siteId` is the ID that you can get if you [add a website](https://matomo.org/faq/how-to/create-and-manage-websites/) within the Matomo web interface. The `baseURL` is the URL to your Matomo web instance and has to include the "piwik.php" or "matomo.php" string.
 
 You can use multiple instances within one application.
 
@@ -172,7 +172,7 @@ matomoTracker.trackGoal(id: 1, revenue: 99.99)
 
 ### Order Tracking
 
-The Matomo iOS SDK supports [order tracking](https://matomo.org/docs/ecommerce-analytics/#tracking-ecommerce-orders-items-purchased-required).
+The Matomo iOS SDK supports [order tracking](https://matomo.org/faq/reports/advanced-manually-tracking-ecommerce-actions-in-matomo/#tracking-orders-to-matomo-required).
 
 ```Swift
 let items = [


### PR DESCRIPTION
A recent knowledge base update has changed how FAQ links work on matomo.org

Links with `#` in the link no longer work for guides or FAQs

I wasn't 100% certain where this link used to go: https://matomo.org/docs/ecommerce-analytics/#tracking-ecommerce-orders-items-purchased-required
So for these I've updated it to point here: https://matomo.org/faq/reports/advanced-manually-tracking-ecommerce-actions-in-matomo/#tracking-orders-to-matomo-required