### PR TITLE
Fix: PrivacyInfo.xcprivacy is not linked when importing by cocoapods

### DIFF
--- a/MatomoTracker.podspec
+++ b/MatomoTracker.podspec
@@ -15,6 +15,10 @@ Pod::Spec.new do |spec|
   
   spec.ios.frameworks = 'UIKit'
   spec.tvos.frameworks = 'UIKit'
+
+  spec.resource_bundles = {
+    'MatomoTracker_Privacy' => ['MatomoTracker/PrivacyInfo.xcprivacy'],
+  }
   
   spec.subspec 'Core' do |core|
   	core.source_files = 'MatomoTracker/*.swift'


### PR DESCRIPTION
As mentionned by [qasimmajeed](https://github.com/qasimmajeed) in issue [#447 (SDKs that require a privacy manifest and signature)](https://github.com/matomo-org/matomo-sdk-ios/issues/447#issuecomment-2119326053), the privacy manifest is not linked in resources when importing MatomoTracker via cocoapods.

The goal of this PR is to link the file privacy manifest in the resources bundle when importing the lib via cocoapods.

Testing : 

1. import MatomoTracker using my branch (`pod 'MatomoTracker', git: 'https://github.com/krazzbeluh/matomo-sdk-ios.git', :branch => 'fix/privacy-manifest-is-not-linked-with-cocoapods'`)
2. pod install
3. The PrivacyInfo.xcprivacy file should be visible in Pods/Pods/MatomoTracker/Resources