### PR TITLE
Make CustomDimension fields public

### DIFF
--- a/MatomoTracker/CustomDimension.swift
+++ b/MatomoTracker/CustomDimension.swift
@@ -3,10 +3,10 @@ import Foundation
 /// For more information on custom dimensions visit https://piwik.org/docs/custom-dimensions/
 public struct CustomDimension: Codable {
     /// The index of the dimension. A dimension with this index must be setup in the Matomo backend.
-    let index: Int
+    public let index: Int
     
     /// The value you want to set for this dimension.
-    let value: String
+    public let value: String
     
     public init(index: Int, value: String) {
       self.index = index


### PR DESCRIPTION
`CustomDimension` is a public struct, but its fields aren't, which makes adding (retroactive) conformance to e.g. `CustomStringConvertible` and `CustomDebugStringConvertible` impossible.