### PR TITLE
Add visionOS support (#433) (#443)

### DIFF
--- a/MatomoTracker.xcodeproj/project.pbxproj
+++ b/MatomoTracker.xcodeproj/project.pbxproj
@@ -509,7 +509,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SUPPORTED_PLATFORMS = "macosx appletvos appletvsimulator iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = "macosx appletvos appletvsimulator iphoneos iphonesimulator xrsimulator xros";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -569,7 +569,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SUPPORTED_PLATFORMS = "macosx appletvos appletvsimulator iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = "macosx appletvos appletvsimulator iphoneos iphonesimulator xrsimulator xros";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -599,7 +599,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.matomo.MatomoTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos macosx xrsimulator xros";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
@@ -625,7 +625,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.matomo.MatomoTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos macosx xrsimulator xros";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				VALID_ARCHS = "i386 x86_64 arm64 armv7 armv7s";

--- a/MatomoTracker/Device.swift
+++ b/MatomoTracker/Device.swift
@@ -95,7 +95,7 @@ extension Device {
             return nil
         }
     }
-#elseif os(iOS) || os(tvOS)
+#elseif os(iOS) || os(tvOS) || os(visionOS)
     import UIKit
     extension Device {
         internal static func operatingSystemForCurrentDevice() -> String {
@@ -105,6 +105,8 @@ extension Device {
             return "tvOS"
             #elseif os(watchOS)
             return "watchOS"
+            #elseif os(visionOS)
+            return "visionOS"
             #endif
         }
         
@@ -115,14 +117,22 @@ extension Device {
         
         // Returns the screen size in points
         internal static func screenSizeForCurrentDevice() ->  CGSize {
+            #if os(visionOS)
+            return CGSize.zero
+            #else
             let bounds = UIScreen.main.bounds
             return bounds.size
+            #endif
         }
         
         // Returns the screen size in pixels
         internal static func nativeScreenSizeForCurrentDevice() ->  CGSize {
+            #if os(visionOS)
+            return CGSize.zero
+            #else
             let bounds = UIScreen.main.nativeBounds
             return bounds.size
+            #endif
         }
     }
 #elseif os(watchOS)


### PR DESCRIPTION
## Description:
This PR introduces initial support for visionOS in a basic form.

## Comment
As outlined in https://github.com/matomo-org/matomo-sdk-ios/issues/433#issue-1769334380 the main challenge is the absence of `UIScreen` on visionOS. Since the concept of a "screen" in visionOS is ambiguous — potentially infinitely large or nonexistent — I have opted for `.zero`. This approach aligns with other APIs (eg. [amplify-swift visionOS example](https://github.com/aws-amplify/amplify-swift/commit/901bee3655634cbda56462eccfbf46ef45a67ddc#diff-695ecd3f0467ab329a508d26d2fe8e7b0c0b48310a635167b939ee5168aa0cb0R121) ) and provides a practical solution for serialization.

## Testing
Currently, the project’s test setup is configured for iOS only. To enable visionOS testing, I have made modifications in a separate branch: https://github.com/oberbeck/matomo-sdk-ios/commit/a8d35474041241fd7e71d27bf2bc5499812038f0
(Note: I updated Nimble to v13, as v12 does not support visionOS.)

##
* resolves #433
* resolves #443