### PR TITLE
remove url from event encoding

### DIFF
--- a/MatomoTracker/EventAPISerializer.swift
+++ b/MatomoTracker/EventAPISerializer.swift
@@ -2,11 +2,14 @@ import Foundation
 
 final class EventAPISerializer {
     internal func queryItems(for event: Event) -> [String: String] {
-        event.queryItems.reduce(into: [String:String]()) {
+        var queryItemsEncoded = event.queryItems.reduce(into: [String:String]()) {
             $0[$1.name] = $1.value
         }.compactMapValues {
             $0.addingPercentEncoding(withAllowedCharacters: .urlQueryParameterAllowed)
         }
+        queryItemsEncoded["url"] = event.url?.absoluteString // already percent encoded
+        return queryItemsEncoded
+
     }
     
     internal func jsonData(for events: [Event]) throws -> Data {

--- a/MatomoTrackerTests/EventAPISerializerSpec.swift
+++ b/MatomoTrackerTests/EventAPISerializerSpec.swift
@@ -11,6 +11,13 @@ class EventAPISerializerSpec: QuickSpec {
                 let encoded = EventAPISerializer().queryItems(for: event)
                 expect(encoded["dimension42"]) == ###"%3B%27%22%7C%5C%2C.%3C%3E%3F%2F%2B_%3D-%29%28%2A%26%5E%25%24%23%40%21"###
             }
+            it("doesn't encode url twice") {
+                let urlString = "é o/oo" 
+                let url = URL(string: urlString)
+                let event = Event.fixture(url: url!)
+                let encoded = EventAPISerializer().queryItems(for: event)
+                expect(encoded["url"]) == "%C3%A9%20o/oo"
+            }
             it("overrides parameters with customParameters") {
                 let event = Event.fixture()
                 let eventWithOverriddenCdt = Event.fixture(customTrackingParameters: ["cdt": "1"])


### PR DESCRIPTION
In EventAPISerializer, all query parameters—including url—are percent-encoded.
However, the url parameter passed to Event is already percent-encoded and gets encoded twice.

For example, Cancérologie is already encoded to Canc%C3%A9rologie.
But then it is encoded again and becomes Canc%25C3%25A9rologie

This creates a mismatch between platforms:
	•	Android sends the correctly encoded URL (single encoding)
	•	iOS sends the double-encoded version

As a result, Matomo displays two separate entries for what should be the same screen/page.

Android:
/Accueil/Cancérologie

iOS: 
/Accueil/Canc%C3%A9rologie

This leads to duplicated pages in the Matomo Dashboard:

Android : 
<img width="330" height="56" alt="Capture d’écran 2025-11-14 à 10 31 45" src="https://github.com/user-attachments/assets/5c7f8ada-e5b5-4eb0-92fc-1544a9e41bc6" />

iOS : 
<img width="348" height="57" alt="Capture d’écran 2025-11-14 à 10 32 01" src="https://github.com/user-attachments/assets/1699b7f9-301d-486b-a181-2e87791c87a7" />

This change aligns the iOS SDK with Android behavior, avoids dashboard duplication, and ensures consistent analytics when URLs contain non-ASCII characters.
