### PR TITLE
Prevent Matomo init from locking until it acquires the MainThread

### DIFF
--- a/MatomoTracker/MatomoTracker.swift
+++ b/MatomoTracker/MatomoTracker.swift
@@ -102,7 +102,9 @@ final public class MatomoTracker: NSObject {
         self.session = Session.current(in: matomoUserDefaults)
         super.init()
         startNewSession()
-        startDispatchTimer()
+        DispatchQueue.main.async {
+            self.startDispatchTimer()
+        }
     }
     
     /// Create and Configure a new Tracker


### PR DESCRIPTION
#### Abstract

Here at Infomaniak we use Matomo across all our Mobile apps and beyond.

Today, Matomo.init() is a locking call that will not return until `startDispatchTimer()` returns.
`startDispatchTimer()` Syncronously requires running on the main thread.

I think it would be good practice to wait at least one runloop before the object starts its timers, as they synchronously require running on the main thread.

#### Issue with Dependency injection

Today, Matomo.init() is a locking call that will not return until `startDispatchTimer()` returns.

On kDrive, we were trying to make a Matomo instance from a background thread (some event needs to be matomoed).
This `Matomo.init()` call is made by a dependency injection library.

This dependency injection library is simultaneously used, *on the main thread*, to resole another object.
So it is already blocked at this stage, waiting for the first matomo resolution to finish.

On the Matomo side, the blocking `startDispatchTimer()` called by the Matomo.init() method would itself perform a `DispatchQueue.main.sync{ }` that creates a deadlock.

#### Proposed solution

The minimalist change would be to wait at least one run loop before post init setup is performed.
Here I'm using a `DispatchQueue.main.async` to do so.

I'm not touching any other code, but now the Matomo.init() method will no longer block until it is able to run some code on the MainThread.