### PR TITLE
Prevent Matomo init from locking until it acquires the MainThread

### DIFF
--- a/MatomoTracker/MatomoTracker.swift
+++ b/MatomoTracker/MatomoTracker.swift
@@ -99,7 +99,9 @@ final public class MatomoTracker: NSObject {
         self.session = Session.current(in: matomoUserDefaults)
         super.init()
         startNewSession()
-        startDispatchTimer()
+        DispatchQueue.main.async {
+            self.startDispatchTimer()
+        }
     }
     
     /// Create and Configure a new Tracker


### PR DESCRIPTION
#### Abstract

Here at Infomaniak we use Matomo across all our Mobile apps and beyond.

Today, Matomo.init() is a locking call that will not return until `startDispatchTimer()` returns.
`startDispatchTimer()` Synchronously requires running on the main thread.

I think it would be good practice to wait at least one run loop before the object starts its timers, as they synchronously require running on the main thread.

#### Issue with Dependency injection

Today, Matomo.init() is a locking call that will not return until `startDispatchTimer()` returns.

On kDrive, we were trying to make a Matomo instance from a background thread (some event needs to be matomoed).
This `Matomo.init()` call is made by a dependency injection library _in the background_

This dependency injection library is simultaneously used, *on the main thread*, to resole another object.
So it is already blocked at this stage, waiting for the first matomo resolution to finish.

On the Matomo side, the blocking `startDispatchTimer()` called by the Matomo.init() method does itself perform a `DispatchQueue.main.sync{ }` that creates a deadlock.

This issue was discovered while opening a deep link to [kDrive iOS](https://github.com/Infomaniak/ios-kDrive), it is open source, as well as the [DI library](https://github.com/Infomaniak/swift-dependency-injection) used in this particular case.

#### Proposed solution

The minimalist change would be to wait at least one run loop before post init setup is performed.
Here I'm using a `DispatchQueue.main.async` to do so.

I'm not touching any other code, but now the Matomo.init() method will no longer block until it is able to run some code on the Main Thread.